### PR TITLE
Fix spelling mistake in XOR documentation

### DIFF
--- a/docs/EasyCommands/operations.md
+++ b/docs/EasyCommands/operations.md
@@ -331,7 +331,7 @@ Behavior varies based on the input types.
 Keywords: ```^, pow, xor```
 
 * **(Bool, Bool)**: Performs the XOR operation on the two given bools.
-* **(Number, Number)**: Raises the first number to t`e power of the second number
+* **(Number, Number)**: Raises the first number to the power of the second number
 * **(Vector, Vector)**: Returns the angle (in degrees) between the two given vectors (get it? ```^```)
 
 ### Modulus


### PR DESCRIPTION
This would have fixed the issue i originally opened #123  for.