### PR TITLE
Minus Operation Support

### DIFF
--- a/EasyCommands.Tests/ParameterParsingTests/OperatorParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/OperatorParameterProcessorTests.cs
@@ -202,6 +202,20 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         }
 
         [TestMethod]
+        public void AssignNegativeVariable() {
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to -t");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
+            Assert.IsTrue(assignment.variable is UniOperandVariable);
+            UniOperandVariable variable = (UniOperandVariable)assignment.variable;
+            Assert.AreEqual(UniOperand.REVERSE, variable.operand);
+            Assert.IsTrue(variable.a is AmbiguousStringVariable);
+            AmbiguousStringVariable memoryVariable = (AmbiguousStringVariable)variable.a;
+            Assert.AreEqual("t", memoryVariable.value);
+        }
+
+        [TestMethod]
         public void AssignSimpleStringSubtractionMultipleCharacters() {
             var program = MDKFactory.CreateProgram<Program>();
             var command = program.ParseCommand("assign a to \"second\" - eco");

--- a/EasyCommands.Tests/ScriptTests/ExampleScriptTests/RotorControlTests.cs
+++ b/EasyCommands.Tests/ScriptTests/ExampleScriptTests/RotorControlTests.cs
@@ -49,10 +49,10 @@ assign newSpeed to ( timeToLimit * myVelocity ) / desiredSecondsToLimit
 
 if isNegative
   if timeToLimit < desiredSecondsToLimit
-    call ""min"" -1 * minRotorRPM newSpeed
+    call ""min"" -minRotorRPM newSpeed
     assign newSpeed to myOutput
   else
-    call ""max"" -1 * maxRotorRPM newSpeed
+    call ""max"" -maxRotorRPM newSpeed
     assign newSpeed to myOutput
 else
   if timeToLimit < desiredSecondsToLimit

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/SimpleVariableTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/SimpleVariableTests.cs
@@ -328,5 +328,195 @@ Print ""a: "" + reverse a
             }
         }
 
+        [TestMethod]
+        public void NegateList() {
+            var script = @"
+set a to [""one""-> 1,2,3]
+Print ""a: "" + -a
+";
+
+            using (var test = new ScriptTest(script)) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("a: [3,2,one->1]", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AssignNegativeVariable() {
+            var script = @"
+set a to 2
+set b to -a
+Print ""b: "" + b
+";
+
+            using (var test = new ScriptTest(script)) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("b: -2", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AssignNegativeVariablePlusValueNegativeResolvesFirst() {
+            var script = @"
+set a to 2
+set b to -a+5
+Print ""b: "" + b
+";
+
+            using (var test = new ScriptTest(script)) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("b: 3", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AssignNegativeVariableTimesValueNegativeResolvesFirst() {
+            var script = @"
+set a to 2
+set b to -a*5
+Print ""b: "" + b
+";
+
+            using (var test = new ScriptTest(script)) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("b: -10", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AssignNegatationTimesNegation() {
+            var script = @"
+set a to 2
+set b to -a*-a
+Print ""b: "" + b
+";
+
+            using (var test = new ScriptTest(script)) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("b: 4", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AssignNegativeNumberMinusVariable() {
+            var script = @"
+set a to 2
+set b to -2-a
+Print ""b: "" + b
+";
+
+            using (var test = new ScriptTest(script)) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("b: -4", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AssignNegativeVariableMinusNumber() {
+            var script = @"
+set a to 2
+set b to -a-2
+Print ""b: "" + b
+";
+
+            using (var test = new ScriptTest(script)) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("b: -4", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AssignNegativeVariableMinusVariable() {
+            var script = @"
+set a to 2
+set b to -a-a
+Print ""b: "" + b
+";
+
+            using (var test = new ScriptTest(script)) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("b: -4", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AssignDoubleNegative() {
+            var script = @"
+set a to 2
+set b to 2 - -a
+Print ""b: "" + b
+";
+
+            using (var test = new ScriptTest(script)) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("b: 4", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AssignParenthesesWrappedSubtractionOperation() {
+            var script = @"
+set a to 2
+set a to (2 - 3) - 1
+print ""a: "" + a
+";
+
+            using (var test = new ScriptTest(script)) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("a: -2", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AssignParenthesesWrappedNegation() {
+            var script = @"
+set a to 2
+set a to (-3) - 1
+print ""a: "" + a
+";
+
+            using (var test = new ScriptTest(script)) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("a: -4", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AssignParenthesesWrappedNegationAndSubtraction() {
+            var script = @"
+set a to 2
+set a to (2 - -3) - 1
+print ""a: "" + a
+";
+
+            using (var test = new ScriptTest(script)) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("a: 4", test.Logger[0]);
+            }
+        }
     }
 }

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -220,10 +220,12 @@ namespace IngameScript {
             AddTier1OperationWords(Words("pow", "exp", "^", "xor"), BiOperand.EXPONENT);
 
             AddTier2OperationWords(Words("plus", "+"), BiOperand.ADD);
-            AddTier2OperationWords(Words("minus", "-"), BiOperand.SUBTRACT);
+            AddTier2OperationWords(Words("minus"), BiOperand.SUBTRACT);
 
             AddTier3OperationWords(Words("as", "cast"), BiOperand.CAST);
             AddTier3OperationWords(Words(".."), BiOperand.RANGE);
+
+            AddWords(Words("-"), new MinusCommandParameter());
 
             //List Words
             AddWords(Words("["), new OpenBracketCommandParameter());

--- a/EasyCommands/CommandParsers/ParameterProcessors.cs
+++ b/EasyCommands/CommandParsers/ParameterProcessors.cs
@@ -49,11 +49,19 @@ namespace IngameScript {
                 for(int j = i + 1; j < p.Count; j++) {
                     if (p[j] is OpenParenthesisCommandParameter) return false;
                     else if (p[j] is CloseParenthesisCommandParameter) {
-                        finalParameters = p.GetRange(i+1, j - (i+1));
-                        var alternateBranches = PROGRAM.ProcessParameters(finalParameters);
+                        var alternateBranches = NewList(p.GetRange(i + 1, j - (i + 1)));
                         p.RemoveRange(i, j - i + 1);
 
+                        while(alternateBranches.Count > 0) {
+                            finalParameters = alternateBranches[0];
+                            alternateBranches.AddRange(PROGRAM.ProcessParameters(finalParameters));
+                            alternateBranches.RemoveAt(0);
+                            if (finalParameters.Count == 1) break;
+                        }
+
                         for (int k = 0; k < alternateBranches.Count; k++) {
+                            alternateBranches[k].Insert(0, new OpenParenthesisCommandParameter());
+                            alternateBranches[k].Add(new CloseParenthesisCommandParameter());
                             var copy = new List<CommandParameter>(p);
                             copy.InsertRange(i, alternateBranches[k]);
                             branches.Add(copy);

--- a/EasyCommands/CommandParsers/ProcessingEngine.cs
+++ b/EasyCommands/CommandParsers/ProcessingEngine.cs
@@ -135,6 +135,12 @@ namespace IngameScript {
             //ListIndexAsVariableProcessor
             NoValueRule(Type<ListIndexCommandParameter>, list => new VariableCommandParameter(list.value)),
 
+            //MinusProcessor
+            new BranchingProcessor<MinusCommandParameter>(
+                NoValueRule(Type<MinusCommandParameter>, minus => new UniOperationCommandParameter(UniOperand.REVERSE)),
+                NoValueRule(Type<MinusCommandParameter>, minus => new BiOperandTier2Operand(BiOperand.SUBTRACT))
+            ),
+
             //AfterUniOperationProcessor
             OneValueRule(Type<LeftUniOperationCommandParameter>, requiredLeft<VariableCommandParameter>(),
                 (p, df) => new VariableCommandParameter(new UniOperandVariable(p.value, df.value))),

--- a/EasyCommands/Commands/CommandParameters.cs
+++ b/EasyCommands/Commands/CommandParameters.cs
@@ -52,6 +52,7 @@ namespace IngameScript {
         public class KeyedVariableCommandParameter : SimpleCommandParameter { }
         public class TernaryConditionIndicatorParameter : SimpleCommandParameter { }
         public class TernaryConditionSeparatorParameter : SimpleCommandParameter { }
+        public class MinusCommandParameter : SimpleCommandParameter { }
 
         public abstract class ValueCommandParameter<T> : CommandParameter {
             public T value;

--- a/docs/EasyCommands/operations.md
+++ b/docs/EasyCommands/operations.md
@@ -68,6 +68,29 @@ Print "Result: " + result
 #Result: 8
 ```
 
+### The Minus Sign
+```-``` can be used as either a UniOperand to negate a value (See the Not Operation)), or as a BiOperand to subtract a value from another value (see the Subtraction operation).
+
+```
+#Negation
+set a to 2
+set b to -a
+print "b: " + b
+#b: -2
+```
+
+```
+#Subtraction
+set a to 2
+set b to 5 - a
+print "b: " + b
+#b: 3
+```
+
+EasyCommands will do its best to infer whether you meant by "-", but may not be perfect.  If needed, use parantheses to clarify your intent.
+
+Negation resolves before subtraction, so ```-a-a``` resolves to ```(-a) - a```, vs ```-(a-a)```.
+
 ## Uni Operations
 
 ### Absolute Value
@@ -113,12 +136,13 @@ set mykeys to myList keys
 Inverses a given property.  Behavior varies by input type
 
 Keywords:
-```not, !, isnt, arent, stop```
+```not, !, isnt, arent, stop, -```
 
 * **(Boolean)**: inverts the boolean
 * **(Number)**: multiplies the number by -1
 * **(Vector)**: returns the inverse of the given vector
 * **(Color)**: returns the inverse of the given color
+* **(List)**: returns a list whose order is reversed
 
 Example:
 ```

--- a/docs/EasyCommands/parsing.md
+++ b/docs/EasyCommands/parsing.md
@@ -14,3 +14,27 @@ Every time EasyCommands executes, it will inspect the CustomData to see if it ha
 
 EasyCommands progressively parses your script to avoid performance impact and to avoid the dreaded "Script Too Complex" issue during parsing.  As such there are no limits on function length or the number of commands any function can have.  That said, your script might still not be able to execute everything in a single tick even if it's able to parse it.  If you find yourself executing too many commands in a single tick and you get the "Script Too Complex" error during execution, consider breaking up your commands into multiple ticks.  The simplest way to do this is to add a ```wait``` command somewhere in your script.
 
+## Bottom to Top Parsing
+If multiple [Functions](https://spaceengineers.merlinofmines.com/EasyCommands/functions "Functions") are present, functions are parsed from the bottom up.  So if your parsing fails at line "55" in function "b", you fix it and then get a parsing exception on line 27 in function "a", that's why.
+
+## Back to Front
+
+EasyCommands parses each command line from back to front.  Seems counter intuitive but it actually leads to many more use cases for natural sounding commands.
+
+This does have some ramifications though.  Commands like the following will not yield the result you might expect:
+
+```
+set a to 2 - 3 - 1
+#Assumed Calculation: (2 - 3) - 1 = -1 - 1 = -2
+#Actual Calculation: 2 - (3 - 1) = 2 - 2 = 0
+
+print "a: " +a
+#a: 0
+```
+
+For these cases, parantheses can help clarify the intended ordering:
+```
+set a to (2 - 3) - 1
+Print "a: " + a
+#a: -2
+```


### PR DESCRIPTION
This commit adds support for "-" to mean either subtraction or negation, depending on it's surrounding context.  This effectively enables support for negating
variables without requiring -1 * variable.  Now you can simply do -variable.  Negation takes precedence, so -a-a = (-a) - a, vs -(a-a).

This commit also changes parentheses processing to throw out branches that do not resolve to a single value.  The new expectation is that anything in parentheses
should resolve to a single value, be it a selector, variable or command.