### PR TITLE
Fixed Power/Enable Properties

### DIFF
--- a/EasyCommands.Tests/EasyCommands.Tests.csproj
+++ b/EasyCommands.Tests/EasyCommands.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\lib\nuget\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\lib\nuget\MSTest.TestAdapter.2.1.2\build\net45\MSTest.TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -143,6 +143,7 @@
     <Compile Include="ParameterParsingTests\TransferCommandProcessorTests.cs" />
     <Compile Include="ScriptTests\BlockHandlerTests\AirVentBlockTests.cs" />
     <Compile Include="ScriptTests\BlockHandlerTests\BeaconBlockTests.cs" />
+    <Compile Include="ScriptTests\BlockHandlerTests\GasTankBlockTests.cs" />
     <Compile Include="ScriptTests\BlockHandlerTests\MergeBlockTests.cs" />
     <Compile Include="ScriptTests\BlockHandlerTests\MagnetBlockTests.cs" />
     <Compile Include="ScriptTests\BlockHandlerTests\LandingGearBlockTests.cs" />

--- a/EasyCommands.Tests/ScriptTests/BlockHandlerTests/AirVentBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/BlockHandlerTests/AirVentBlockTests.cs
@@ -10,6 +10,30 @@ namespace EasyCommands.Tests.ScriptTests {
     [TestClass]
     public class AirVentBlockTests {
         [TestMethod]
+        public void TurnOnTheAirVent() {
+            using (ScriptTest test = new ScriptTest(@"turn on the ""test airVent""")) {
+                Mock<IMyAirVent> mockAirVent = new Mock<IMyAirVent>();
+                test.MockBlocksOfType("test airVent", mockAirVent);
+
+                test.RunUntilDone();
+
+                mockAirVent.VerifySet(b => b.Enabled = true);
+            }
+        }
+
+        [TestMethod]
+        public void TurnOffTheAirVent() {
+            using (ScriptTest test = new ScriptTest(@"turn off the ""test airVent""")) {
+                Mock<IMyAirVent> mockAirVent = new Mock<IMyAirVent>();
+                test.MockBlocksOfType("test airVent", mockAirVent);
+
+                test.RunUntilDone();
+
+                mockAirVent.VerifySet(b => b.Enabled = false);
+            }
+        }
+
+        [TestMethod]
         public void PressurizeTheAirVent() {
             using (ScriptTest test = new ScriptTest(@"pressurize the ""test airVent""")) {
                 Mock<IMyAirVent> mockAirVent= new Mock<IMyAirVent>();

--- a/EasyCommands.Tests/ScriptTests/BlockHandlerTests/AssemblerBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/BlockHandlerTests/AssemblerBlockTests.cs
@@ -10,6 +10,54 @@ namespace EasyCommands.Tests.ScriptTests {
     [TestClass]
     public class AssemblerBlockTests {
         [TestMethod]
+        public void TurnOnTheAssembler() {
+            using (ScriptTest test = new ScriptTest(@"turn on the ""test assembler""")) {
+                Mock<IMyAssembler> mockAssembler = new Mock<IMyAssembler>();
+                test.MockBlocksOfType("test assembler", mockAssembler);
+
+                test.RunUntilDone();
+
+                mockAssembler.VerifySet(b => b.Enabled = true);
+            }
+        }
+
+        [TestMethod]
+        public void TurnOffTheAssembler() {
+            using (ScriptTest test = new ScriptTest(@"turn off the ""test assembler""")) {
+                Mock<IMyAssembler> mockAssembler = new Mock<IMyAssembler>();
+                test.MockBlocksOfType("test assembler", mockAssembler);
+
+                test.RunUntilDone();
+
+                mockAssembler.VerifySet(b => b.Enabled = false);
+            }
+        }
+
+        [TestMethod]
+        public void StartTheAssembler() {
+            using (ScriptTest test = new ScriptTest(@"start the ""test assembler""")) {
+                Mock<IMyAssembler> mockAssembler = new Mock<IMyAssembler>();
+                test.MockBlocksOfType("test assembler", mockAssembler);
+
+                test.RunUntilDone();
+
+                mockAssembler.VerifySet(b => b.Enabled = true);
+            }
+        }
+
+        [TestMethod]
+        public void StopTheAssembler() {
+            using (ScriptTest test = new ScriptTest(@"stop the ""test assembler""")) {
+                Mock<IMyAssembler> mockAssembler = new Mock<IMyAssembler>();
+                test.MockBlocksOfType("test assembler", mockAssembler);
+
+                test.RunUntilDone();
+
+                mockAssembler.VerifySet(b => b.Enabled = false);
+            }
+        }
+
+        [TestMethod]
         public void TellAssemblerToSupply() {
             using(ScriptTest test = new ScriptTest(@"tell the ""test assembler"" to supply")) {
                 Mock<IMyAssembler> mockAssembler = new Mock<IMyAssembler>();
@@ -119,18 +167,6 @@ namespace EasyCommands.Tests.ScriptTests {
                 test.RunUntilDone();
 
                 Assert.IsTrue(test.Logger.Contains("Steel Plate Remaining: 100"));
-            }
-        }
-
-        [TestMethod]
-        public void StopTheAssembler() {
-            using (ScriptTest test = new ScriptTest(@"stop the ""test assembler""")) {
-                Mock<IMyAssembler> mockAssembler = new Mock<IMyAssembler>();
-                test.MockBlocksOfType("test assembler", mockAssembler);
-
-                test.RunUntilDone();
-
-                mockAssembler.Verify(b => b.ClearQueue());
             }
         }
 

--- a/EasyCommands.Tests/ScriptTests/BlockHandlerTests/BatteryBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/BlockHandlerTests/BatteryBlockTests.cs
@@ -9,6 +9,28 @@ namespace EasyCommands.Tests.ScriptTests {
     [TestClass]
     public class BatteryBlockTests {
         [TestMethod]
+        public void TurnOnTheBattery() {
+            using (ScriptTest test = new ScriptTest(@"turn on the ""test battery""")) {
+                Mock<IMyBatteryBlock> mockBattery = new Mock<IMyBatteryBlock>();
+                test.MockBlocksOfType("test battery", mockBattery);
+                test.RunUntilDone();
+
+                mockBattery.VerifySet(b => b.Enabled = true);
+            }
+        }
+
+        [TestMethod]
+        public void TurnOffTheBattery() {
+            using (ScriptTest test = new ScriptTest(@"turn off the ""test battery""")) {
+                Mock<IMyBatteryBlock> mockBattery = new Mock<IMyBatteryBlock>();
+                test.MockBlocksOfType("test battery", mockBattery);
+                test.RunUntilDone();
+
+                mockBattery.VerifySet(b => b.Enabled = false);
+            }
+        }
+
+        [TestMethod]
         public void GetTheBatteryLevel() {
             using (ScriptTest test = new ScriptTest(@"Print ""Stored Power: "" + the ""test battery"" level")) {
                 Mock<IMyBatteryBlock> mockBattery = new Mock<IMyBatteryBlock>();

--- a/EasyCommands.Tests/ScriptTests/BlockHandlerTests/CameraBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/BlockHandlerTests/CameraBlockTests.cs
@@ -9,6 +9,30 @@ namespace EasyCommands.Tests.ScriptTests {
     [TestClass]
     public class CameraBlockTests {
         [TestMethod]
+        public void TurnOnTheCamera() {
+            using (var test = new ScriptTest(@"turn on the ""test camera""")) {
+                var mockCamera = new Mock<IMyCameraBlock>();
+                test.MockBlocksOfType("test camera", mockCamera);
+
+                test.RunUntilDone();
+
+                mockCamera.VerifySet(c => c.Enabled = true);
+            }
+        }
+
+        [TestMethod]
+        public void TurnOffTheCamera() {
+            using (var test = new ScriptTest(@"turn off the ""test camera""")) {
+                var mockCamera = new Mock<IMyCameraBlock>();
+                test.MockBlocksOfType("test camera", mockCamera);
+
+                test.RunUntilDone();
+
+                mockCamera.VerifySet(c => c.Enabled = false);
+            }
+        }
+
+        [TestMethod]
         public void getCameraRange() {
             String script = @"
 assign ""a"" to ""mock camera"" range

--- a/EasyCommands.Tests/ScriptTests/BlockHandlerTests/CockpitBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/BlockHandlerTests/CockpitBlockTests.cs
@@ -10,6 +10,30 @@ namespace EasyCommands.Tests.ScriptTests {
     [TestClass]
     public class CockpitBlockTests {
         [TestMethod]
+        public void TurnOnTheCockpit() {
+            using (ScriptTest test = new ScriptTest(@"turn on the ""test cockpit""")) {
+                Mock<IMyCockpit> mockCockpit = new Mock<IMyCockpit>();
+                test.MockBlocksOfType("test cockpit", mockCockpit);
+
+                test.RunUntilDone();
+
+                mockCockpit.VerifySet(b => b.IsMainCockpit = true);
+            }
+        }
+
+        [TestMethod]
+        public void TurnOffTheCockpit() {
+            using (ScriptTest test = new ScriptTest(@"turn off the ""test cockpit""")) {
+                Mock<IMyCockpit> mockCockpit = new Mock<IMyCockpit>();
+                test.MockBlocksOfType("test cockpit", mockCockpit);
+
+                test.RunUntilDone();
+
+                mockCockpit.VerifySet(b => b.IsMainCockpit = false);
+            }
+        }
+
+        [TestMethod]
         public void EnableTheCockpit() {
             using (ScriptTest test = new ScriptTest(@"enable the ""test cockpit""")) {
                 Mock<IMyCockpit> mockCockpit = new Mock<IMyCockpit>();

--- a/EasyCommands.Tests/ScriptTests/BlockHandlerTests/GasTankBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/BlockHandlerTests/GasTankBlockTests.cs
@@ -1,0 +1,132 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using Moq;
+using Sandbox.ModAPI.Ingame;
+
+namespace EasyCommands.Tests.ScriptTests {
+    [TestClass]
+    public class GasTankBlockTests {
+        [TestMethod]
+        public void TurnOnTheGasTank() {
+            using (ScriptTest test = new ScriptTest(@"turn on the ""test tank""")) {
+                Mock<IMyGasTank> mockTank = new Mock<IMyGasTank>();
+                test.MockBlocksOfType("test tank", mockTank);
+
+                test.RunUntilDone();
+
+                mockTank.VerifySet(b => b.Enabled = true);
+            }
+        }
+
+        [TestMethod]
+        public void TurnOffTheGasTank() {
+            using (ScriptTest test = new ScriptTest(@"turn off the ""test tank""")) {
+                Mock<IMyGasTank> mockTank = new Mock<IMyGasTank>();
+                test.MockBlocksOfType("test tank", mockTank);
+
+                test.RunUntilDone();
+
+                mockTank.VerifySet(b => b.Enabled = false);
+            }
+        }
+
+        [TestMethod]
+        public void SetTheGasTankToAuto() {
+            using (ScriptTest test = new ScriptTest(@"set the ""test tank"" to auto")) {
+                Mock<IMyGasTank> mockTank = new Mock<IMyGasTank>();
+                test.MockBlocksOfType("test tank", mockTank);
+
+                test.RunUntilDone();
+
+                mockTank.VerifySet(b => b.AutoRefillBottles = true);
+            }
+        }
+
+        [TestMethod]
+        public void TellTheGasTankToRefill() {
+            using (ScriptTest test = new ScriptTest(@"tell the ""test tank"" to refill")) {
+                Mock<IMyGasTank> mockTank = new Mock<IMyGasTank>();
+                test.MockBlocksOfType("test tank", mockTank);
+
+                test.RunUntilDone();
+
+                mockTank.VerifySet(b => b.AutoRefillBottles = true);
+            }
+        }
+
+        [TestMethod]
+        public void IsTheGasTankStockpiling() {
+            using (ScriptTest test = new ScriptTest(@"Print ""Stockpiling: "" + the ""test tank"" is stockpiling")) {
+                Mock<IMyGasTank> mockTank = new Mock<IMyGasTank>();
+                test.MockBlocksOfType("test tank", mockTank);
+                mockTank.Setup(b => b.Stockpile).Returns(true);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Stockpiling: True", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void TellTheGasTankToStockpile() {
+            using (ScriptTest test = new ScriptTest(@"tell the ""test tank"" to stockpile")) {
+                Mock<IMyGasTank> mockTank = new Mock<IMyGasTank>();
+                test.MockBlocksOfType("test tank", mockTank);
+
+                test.RunUntilDone();
+
+                mockTank.VerifySet(b => b.Stockpile = true);
+            }
+        }
+
+        [TestMethod]
+        public void TellTheGasTankToSupply() {
+            using (ScriptTest test = new ScriptTest(@"tell the ""test tank"" to supply")) {
+                Mock<IMyGasTank> mockTank = new Mock<IMyGasTank>();
+                test.MockBlocksOfType("test tank", mockTank);
+
+                test.RunUntilDone();
+
+                mockTank.VerifySet(b => b.Stockpile = false);
+            }
+        }
+
+        [TestMethod]
+        public void TellTheGasTankToStopStockpiling() {
+            using (ScriptTest test = new ScriptTest(@"tell the ""test tank"" to stop stockpiling")) {
+                Mock<IMyGasTank> mockTank = new Mock<IMyGasTank>();
+                test.MockBlocksOfType("test tank", mockTank);
+
+                test.RunUntilDone();
+
+                mockTank.VerifySet(b => b.Stockpile = false);
+            }
+        }
+
+        [TestMethod]
+        public void GetTheTankCapacity() {
+            using (ScriptTest test = new ScriptTest(@"Print ""Capacity: "" + the ""test tank"" capacity")) {
+                Mock<IMyGasTank> mockTank = new Mock<IMyGasTank>();
+                test.MockBlocksOfType("test tank", mockTank);
+                mockTank.Setup(b => b.Capacity).Returns(10000f);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Capacity: 10000", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void GetTheTankRatio() {
+            using (ScriptTest test = new ScriptTest(@"Print ""Ratio: "" + the ""test tank"" ratio")) {
+                Mock<IMyGasTank> mockTank = new Mock<IMyGasTank>();
+                test.MockBlocksOfType("test tank", mockTank);
+                mockTank.Setup(b => b.FilledRatio).Returns(0.4);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Ratio: 0.4", test.Logger[0]);
+            }
+        }
+    }
+}

--- a/EasyCommands.Tests/ScriptTests/BlockHandlerTests/GasTankBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/BlockHandlerTests/GasTankBlockTests.cs
@@ -128,5 +128,19 @@ namespace EasyCommands.Tests.ScriptTests {
                 Assert.AreEqual("Ratio: 0.4", test.Logger[0]);
             }
         }
+
+        [TestMethod]
+        public void GetTheTankLevel() {
+            using (ScriptTest test = new ScriptTest(@"Print ""Level: "" + the ""test tank"" level")) {
+                Mock<IMyGasTank> mockTank = new Mock<IMyGasTank>();
+                test.MockBlocksOfType("test tank", mockTank);
+                mockTank.Setup(b => b.FilledRatio).Returns(0.4);
+                mockTank.Setup(b => b.Capacity).Returns(10000);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Level: 4000", test.Logger[0]);
+            }
+        }
     }
 }

--- a/EasyCommands.Tests/ScriptTests/BlockHandlerTests/ParachuteBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/BlockHandlerTests/ParachuteBlockTests.cs
@@ -11,6 +11,30 @@ namespace EasyCommands.Tests.ScriptTests {
     [TestClass]
     public class ParachuteBlockTests {
         [TestMethod]
+        public void TurnOnTheParachute() {
+            using (ScriptTest test = new ScriptTest(@"turn on the ""test parachute""")) {
+                Mock<IMyParachute> mockParachute = new Mock<IMyParachute>();
+                test.MockBlocksOfType("test parachute", mockParachute);
+
+                test.RunUntilDone();
+
+                mockParachute.VerifySet(b => b.Enabled = true);
+            }
+        }
+
+        [TestMethod]
+        public void TurnOffTheParachute() {
+            using (ScriptTest test = new ScriptTest(@"turn off the ""test parachute""")) {
+                Mock<IMyParachute> mockParachute = new Mock<IMyParachute>();
+                test.MockBlocksOfType("test parachute", mockParachute);
+
+                test.RunUntilDone();
+
+                mockParachute.VerifySet(b => b.Enabled = false);
+            }
+        }
+
+        [TestMethod]
         public void OpenTheParachute() {
             using (ScriptTest test = new ScriptTest(@"open the ""test parachute""")) {
                 Mock<IMyParachute> mockParachute = new Mock<IMyParachute>();

--- a/EasyCommands.Tests/ScriptTests/BlockHandlerTests/RemoteControlBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/BlockHandlerTests/RemoteControlBlockTests.cs
@@ -23,8 +23,56 @@ namespace EasyCommands.Tests.ScriptTests {
         }
 
         [TestMethod]
-        public void DisableTheCockpit() {
+        public void DisableTheRemoteControl() {
             using (ScriptTest test = new ScriptTest(@"disable the ""test remote control""")) {
+                Mock<IMyRemoteControl> mockRemoteControl = new Mock<IMyRemoteControl>();
+                test.MockBlocksOfType("test remote control", mockRemoteControl);
+
+                test.RunUntilDone();
+
+                mockRemoteControl.VerifySet(b => b.IsMainCockpit = false);
+            }
+        }
+
+        [TestMethod]
+        public void TurnOnTheRemoteControl() {
+            using (ScriptTest test = new ScriptTest(@"turn on the ""test remote control""")) {
+                Mock<IMyRemoteControl> mockRemoteControl = new Mock<IMyRemoteControl>();
+                test.MockBlocksOfType("test remote control", mockRemoteControl);
+
+                test.RunUntilDone();
+
+                mockRemoteControl.Verify(b => b.SetAutoPilotEnabled(true));
+            }
+        }
+
+        [TestMethod]
+        public void TurnOffTheRemoteControl() {
+            using (ScriptTest test = new ScriptTest(@"turn off the ""test remote control""")) {
+                Mock<IMyRemoteControl> mockRemoteControl = new Mock<IMyRemoteControl>();
+                test.MockBlocksOfType("test remote control", mockRemoteControl);
+
+                test.RunUntilDone();
+
+                mockRemoteControl.Verify(b => b.SetAutoPilotEnabled(false));
+            }
+        }
+
+        [TestMethod]
+        public void TurnOnPowerToTheRemoteControl() {
+            using (ScriptTest test = new ScriptTest(@"turn on power to the ""test remote control""")) {
+                Mock<IMyRemoteControl> mockRemoteControl = new Mock<IMyRemoteControl>();
+                test.MockBlocksOfType("test remote control", mockRemoteControl);
+
+                test.RunUntilDone();
+
+                mockRemoteControl.VerifySet(b => b.IsMainCockpit = true);
+            }
+        }
+
+        [TestMethod]
+        public void TurnOffPowerToTheRemoteControl() {
+            using (ScriptTest test = new ScriptTest(@"turn off power to the ""test remote control""")) {
                 Mock<IMyRemoteControl> mockRemoteControl = new Mock<IMyRemoteControl>();
                 test.MockBlocksOfType("test remote control", mockRemoteControl);
 
@@ -82,18 +130,6 @@ namespace EasyCommands.Tests.ScriptTests {
                 test.RunUntilDone();
 
                 Assert.AreEqual("Remote Control Auto: True", test.Logger[0]);
-            }
-        }
-
-        [TestMethod]
-        public void TurnOnTheRemoteControl() {
-            using (ScriptTest test = new ScriptTest(@"turn on the ""test remote control""")) {
-                Mock<IMyRemoteControl> mockRemoteControl = new Mock<IMyRemoteControl>();
-                test.MockBlocksOfType("test remote control", mockRemoteControl);
-
-                test.RunUntilDone();
-
-                mockRemoteControl.Verify(b => b.SetAutoPilotEnabled(true));
             }
         }
 

--- a/EasyCommands.Tests/ScriptTests/BlockHandlerTests/SensorBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/BlockHandlerTests/SensorBlockTests.cs
@@ -9,6 +9,54 @@ namespace EasyCommands.Tests.ScriptTests {
     [TestClass]
     public class SensorBlockTests {
         [TestMethod]
+        public void TurnOnTheSensor() {
+            using (var test = new ScriptTest(@"turn on the ""test sensor""")) {
+                var mockSensor = new Mock<IMySensorBlock>();
+                test.MockBlocksOfType("test sensor", mockSensor);
+
+                test.RunOnce();
+
+                mockSensor.VerifySet(b => b.Enabled = true);
+            }
+        }
+
+        [TestMethod]
+        public void TurnOffTheSensor() {
+            using (var test = new ScriptTest(@"turn off the ""test sensor""")) {
+                var mockSensor = new Mock<IMySensorBlock>();
+                test.MockBlocksOfType("test sensor", mockSensor);
+
+                test.RunOnce();
+
+                mockSensor.VerifySet(b => b.Enabled = false);
+            }
+        }
+
+        [TestMethod]
+        public void TurnOnTheSensorSound() {
+            using (var test = new ScriptTest(@"turn on the ""test sensor"" sound")) {
+                var mockSensor = new Mock<IMySensorBlock>();
+                test.MockBlocksOfType("test sensor", mockSensor);
+
+                test.RunOnce();
+
+                mockSensor.VerifySet(b => b.PlayProximitySound = true);
+            }
+        }
+
+        [TestMethod]
+        public void TurnOffTheSensorSound() {
+            using (var test = new ScriptTest(@"turn off the ""test sensor"" sound")) {
+                var mockSensor = new Mock<IMySensorBlock>();
+                test.MockBlocksOfType("test sensor", mockSensor);
+
+                test.RunOnce();
+
+                mockSensor.VerifySet(b => b.PlayProximitySound = false);
+            }
+        }
+
+        [TestMethod]
         public void SensorTargetReturnsZeroVectorWhenNothingDetected() {
             String script = @"
 print ""Target: "" + ""mock sensor"" target

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockCommandTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockCommandTests.cs
@@ -357,7 +357,7 @@ namespace EasyCommands.Tests.ScriptTests {
 
                 test.RunUntilDone();
 
-                mockAssembler.Verify(b => b.ClearQueue());
+                mockAssembler.VerifySet(b => b.Enabled = false);
             }
         }
 

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/SimpleSelectorTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/SimpleSelectorTests.cs
@@ -107,7 +107,7 @@ namespace EasyCommands.Tests.ScriptTests {
 
                 test.RunOnce();
 
-                mockBattery.VerifySet(b => b.ChargeMode = ChargeMode.Auto);
+                mockBattery.VerifySet(b => b.Enabled = true);
             }
         }
 

--- a/EasyCommands/BlockHandlers/AirVentBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/AirVentBlockHandlers.cs
@@ -27,7 +27,6 @@ namespace IngameScript {
                 AddNumericHandler(Property.RATIO, b => b.GetOxygenLevel());
                 AddNumericHandler(Property.LEVEL, b => b.GetOxygenLevel());
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.RATIO;
-                defaultPropertiesByPrimitive[Return.BOOLEAN] = Property.SUPPLY;
                 defaultPropertiesByDirection[Direction.UP] = Property.RATIO;
             }
 

--- a/EasyCommands/BlockHandlers/AssemblerBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/AssemblerBlockHandlers.cs
@@ -37,7 +37,6 @@ namespace IngameScript {
                     Get = (b, v) => ResolvePrimitive(GetProducingAmount(b, v)),
                     Set = (b, p, v) => AddQueueItem(b, p)
                 });
-                defaultPropertiesByPrimitive[Return.BOOLEAN] = Property.COMPLETE;
             }
 
             float GetRequestedAmount(PropertySupplier p) => CastNumber(NewList(p.attributeValue.GetValue(), (p.propertyValue ?? GetStaticVariable(1)).GetValue()).Find(v => v.returnType == Return.NUMERIC) ?? ResolvePrimitive(1));

--- a/EasyCommands/BlockHandlers/BatteryBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/BatteryBlockHandlers.cs
@@ -29,7 +29,6 @@ namespace IngameScript {
                 AddNumericHandler(Property.VOLUME, b => b.CurrentOutput);
                 AddNumericHandler(Property.LEVEL, b => b.CurrentStoredPower);
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.RATIO;
-                defaultPropertiesByPrimitive[Return.BOOLEAN] = Property.SUPPLY;
                 defaultPropertiesByDirection[Direction.UP] = Property.RATIO;
              }
         }

--- a/EasyCommands/BlockHandlers/CameraBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/CameraBlockHandlers.cs
@@ -39,7 +39,6 @@ namespace IngameScript {
                     }
                     return GetVector(GetCustomProperty(b, "Target") ?? "").GetValueOrDefault();
                 });
-                defaultPropertiesByPrimitive[Return.BOOLEAN] = Property.TRIGGER;
                 defaultPropertiesByPrimitive[Return.VECTOR] = Property.TARGET;
                 defaultPropertiesByDirection[Direction.UP] = Property.RANGE;
             }

--- a/EasyCommands/BlockHandlers/GasTankBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/GasTankBlockHandlers.cs
@@ -26,7 +26,6 @@ namespace IngameScript {
                 AddNumericHandler(Property.RANGE, (b) => b.Capacity);
                 AddNumericHandler(Property.RATIO, (b) => (float)b.FilledRatio);
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.RATIO;
-                defaultPropertiesByPrimitive[Return.BOOLEAN] = Property.AUTO;
                 defaultPropertiesByDirection.Add(Direction.UP, Property.RATIO);
             }
         }

--- a/EasyCommands/BlockHandlers/GasTankBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/GasTankBlockHandlers.cs
@@ -21,10 +21,11 @@ namespace IngameScript {
     partial class Program {
         public class GasTankBlockHandler : FunctionalBlockHandler<IMyGasTank> {
             public GasTankBlockHandler() {
-                AddBooleanHandler(Property.SUPPLY, (b) => !b.Stockpile, (b, v) => b.Stockpile = !v);
-                AddBooleanHandler(Property.AUTO, (b) => b.AutoRefillBottles, (b, v) => b.AutoRefillBottles = v);
-                AddNumericHandler(Property.RANGE, (b) => b.Capacity);
-                AddNumericHandler(Property.RATIO, (b) => (float)b.FilledRatio);
+                AddBooleanHandler(Property.SUPPLY, b => !b.Stockpile, (b, v) => b.Stockpile = !v);
+                AddBooleanHandler(Property.AUTO, b => b.AutoRefillBottles, (b, v) => b.AutoRefillBottles = v);
+                AddNumericHandler(Property.RANGE, b => b.Capacity);
+                AddNumericHandler(Property.RATIO, b => (float)b.FilledRatio);
+                AddNumericHandler(Property.LEVEL, b => (float)(b.FilledRatio * b.Capacity));
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.RATIO;
                 defaultPropertiesByDirection.Add(Direction.UP, Property.RATIO);
             }

--- a/EasyCommands/BlockHandlers/ParachuteBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/ParachuteBlockHandlers.cs
@@ -33,7 +33,6 @@ namespace IngameScript {
                     Vector3D? closestPoint;
                     return (float)(b.TryGetClosestPoint(out closestPoint) ? closestPoint.Value.Length() : -1);
                 });
-                defaultPropertiesByPrimitive[Return.BOOLEAN] = Property.OPEN;
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.LEVEL;
                 defaultPropertiesByDirection.Add(Direction.UP, Property.RATIO);
             }

--- a/EasyCommands/BlockHandlers/SensorBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/SensorBlockHandlers.cs
@@ -36,7 +36,6 @@ namespace IngameScript {
                     return hitPosition;
                 });
 
-                defaultPropertiesByPrimitive[Return.BOOLEAN] = Property.TRIGGER;
                 defaultPropertiesByPrimitive[Return.VECTOR] = Property.TARGET;
             }
         }

--- a/EasyCommands/BlockHandlers/ShipControllerHandlers.cs
+++ b/EasyCommands/BlockHandlers/ShipControllerHandlers.cs
@@ -34,10 +34,9 @@ namespace IngameScript {
                         return new KeyedList(waypoints.Select(w => new KeyedVariable(GetStaticVariable(w.Name), GetStaticVariable(w.Coords))).ToArray());
                     },
                     SetWaypoints);
-
+                defaultPropertiesByPrimitive[Return.BOOLEAN] = Property.AUTO;
                 defaultPropertiesByPrimitive[Return.VECTOR] = Property.TARGET;
                 defaultPropertiesByPrimitive[Return.LIST] = Property.WAYPOINTS;
-                defaultPropertiesByPrimitive[Return.BOOLEAN] = Property.AUTO;
             }
 
             void SetWaypoints(IMyRemoteControl b, KeyedList waypoints) {
@@ -52,7 +51,9 @@ namespace IngameScript {
         public class ShipControllerHandler<T> : TerminalBlockHandler<T> where T : class, IMyShipController {
             public ShipControllerHandler() {
                 var dampenerHandler = BooleanHandler(b => b.DampenersOverride, (b, v) => b.DampenersOverride = v);
-                AddBooleanHandler(Property.ENABLE, b => b.IsMainCockpit, (b, v) => b.IsMainCockpit = v);
+                var enableHandler = BooleanHandler(b => b.IsMainCockpit, (b, v) => b.IsMainCockpit = v);
+                AddPropertyHandler(Property.ENABLE, enableHandler);
+                AddPropertyHandler(Property.POWER, enableHandler);
                 AddPropertyHandler(Property.OVERRIDE, dampenerHandler);
                 AddPropertyHandler(Property.AUTO, dampenerHandler);
                 AddBooleanHandler(Property.LOCKED, b => b.HandBrake, (b, v) => b.HandBrake = v);
@@ -83,7 +84,7 @@ namespace IngameScript {
                     TypeHandler(NumericHandler(b => -b.RollIndicator), Direction.COUNTERCLOCKWISE),
                     TypeHandler(NumericHandler(b => b.RollIndicator), Direction.CLOCKWISE));
 
-                defaultPropertiesByPrimitive[Return.BOOLEAN] = Property.ENABLE;
+                defaultPropertiesByPrimitive[Return.BOOLEAN] = Property.POWER;
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.VELOCITY;
                 defaultPropertiesByDirection[Direction.UP] = Property.VELOCITY;
             }

--- a/EasyCommands/BlockHandlers/ShipControllerHandlers.cs
+++ b/EasyCommands/BlockHandlers/ShipControllerHandlers.cs
@@ -84,7 +84,7 @@ namespace IngameScript {
                     TypeHandler(NumericHandler(b => -b.RollIndicator), Direction.COUNTERCLOCKWISE),
                     TypeHandler(NumericHandler(b => b.RollIndicator), Direction.CLOCKWISE));
 
-                defaultPropertiesByPrimitive[Return.BOOLEAN] = Property.POWER;
+                defaultPropertiesByPrimitive[Return.BOOLEAN] = Property.ENABLE;
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.VELOCITY;
                 defaultPropertiesByDirection[Direction.UP] = Property.VELOCITY;
             }

--- a/EasyCommands/BlockHandlers/TerminalBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/TerminalBlockHandlers.cs
@@ -54,9 +54,10 @@ namespace IngameScript {
 
         public class FunctionalBlockHandler<T> : TerminalBlockHandler<T> where T : class, IMyFunctionalBlock {
             public FunctionalBlockHandler() : base() {
-                AddBooleanHandler(Property.ENABLE, b => b.Enabled, (b, v) => b.Enabled = v);
-                AddBooleanHandler(Property.POWER, b => b.Enabled, (b, v) => b.Enabled = v);
-                defaultPropertiesByPrimitive[Return.BOOLEAN] = Property.POWER;
+                var enableHandler = BooleanHandler(b => b.Enabled, (b, v) => b.Enabled = v);
+                AddPropertyHandler(Property.ENABLE, enableHandler);
+                AddPropertyHandler(Property.POWER, enableHandler);
+                defaultPropertiesByPrimitive[Return.BOOLEAN] = Property.ENABLE;
             }
         }
 

--- a/EasyCommands/BlockHandlers/TextSurfaceHandlers.cs
+++ b/EasyCommands/BlockHandlers/TextSurfaceHandlers.cs
@@ -45,7 +45,6 @@ namespace IngameScript {
                     TypeHandler(fontSizeHandler, Return.NUMERIC),
                     TypeHandler(fontColorHandler, Return.COLOR));
 
-                defaultPropertiesByPrimitive[Return.BOOLEAN] = Property.ENABLE;
                 defaultPropertiesByPrimitive[Return.STRING] = Property.TEXT;
                 defaultPropertiesByPrimitive[Return.COLOR] = Property.COLOR;
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.LEVEL;

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -117,7 +117,7 @@ namespace IngameScript {
             AddPropertyWords(PluralWords("falloff"), Property.FALLOFF);
             AddPropertyWords(Words("trigger", "triggered", "detect", "detected", "trip", "tripped", "deploy", "deployed", "shoot", "shooting", "shot", "detonate"), Property.TRIGGER);
             AddPropertyWords(Words("pressure", "pressurize", "pressurizing", "supply", "supplying", "generate", "generating", "discharge", "discharging", "broadcast", "broadcasting", "assemble", "assembling"), Property.SUPPLY);
-            AddPropertyWords(Words("stockpile", "depressurize", "depressurizing", "gather", "gathering", "intake", "recharge", "recharging", "consume", "consuming", "collect", "collecting", "disassemble", "disassembling"), Property.SUPPLY, false);
+            AddPropertyWords(Words("stockpile", "stockpiling", "depressurize", "depressurizing", "gather", "gathering", "intake", "recharge", "recharging", "consume", "consuming", "collect", "collecting", "disassemble", "disassembling"), Property.SUPPLY, false);
             AddPropertyWords(AllWords(PluralWords("ratio", "percentage", "percent", "completion"), Words("progress", "progresses")), Property.RATIO);
             AddPropertyWords(PluralWords("input", "pilot", "user"), Property.INPUT);
             AddPropertyWords(PluralWords("roll", "rollInput", "rotation"), Property.ROLL_INPUT);

--- a/docs/EasyCommands/blockHandlers/airvent.md
+++ b/docs/EasyCommands/blockHandlers/airvent.md
@@ -6,11 +6,45 @@ This Block Handler handles Air Vents. Pretty Straightforward
 * Block Type Group Keywords: ```vents, airvents```
 
 Default Primitive Properties:
-* Boolean - Pressurized (replaces "enabled" from Terminal Block Handler)
 * Numeric - Ratio
 
 Default Directional Properties
 * Up - Ratio
+
+## "Enabled" Property
+* Primitive Type: Bool
+* Keywords: ```enable, enabled```
+* Inverse Keywords: ```disable, disabled```
+
+Enables or Disables the given block
+
+```
+#Enable Block
+enable "My Airvent"
+set "My Airvent" to enabled
+turn on "My Airvent"
+
+#Disable Block
+disable "My Airvent"
+set "My Airvent" to disabled
+turn off "My Airvent"
+```
+
+## "Power" Property
+* Primitive Type: Bool
+* Keywords: ```power, powered```
+
+Turns on or off power to the block.  Effectively the same as the Enabled property.
+
+```
+#Turn on
+turn on power to "My Airvent"
+power on "My Airvent"
+
+#Turn off
+turn off power to "My Airvent"
+power off "My Airvent"
+```
 
 ## "Complete" property
 * Read-only

--- a/docs/EasyCommands/blockHandlers/assembler.md
+++ b/docs/EasyCommands/blockHandlers/assembler.md
@@ -7,8 +7,40 @@ For more information on what items you can create or destroy, see [Items & Bluep
 * Block Type Keywords: ```assembler```
 * Block Type Group Keywords: ```assemblers```
 
-Default Primitive Properties:
-* Bool: Complete (Overrides "Enabled" from Terminal Block)
+## "Enabled" Property
+* Primitive Type: Bool
+* Keywords: ```enable, enabled```
+* Inverse Keywords: ```disable, disabled```
+
+Enables or Disables the given block
+
+```
+#Enable Block
+enable "My Assembler"
+set "My Assembler" to enabled
+turn on "My Assembler"
+
+#Disable Block
+disable "My Assembler"
+set "My Assembler" to disabled
+turn off "My Assembler"
+```
+
+## "Power" Property
+* Primitive Type: Bool
+* Keywords: ```power, powered```
+
+Turns on or off power to the block.  Effectively the same as the Enabled property.
+
+```
+#Turn on
+turn on power to "My Assembler"
+power on "My Assembler"
+
+#Turn off
+turn off power to "My Assembler"
+power off "My Assembler"
+```
 
 ## "Supply" Property
 * Primitive Type: Bool

--- a/docs/EasyCommands/blockHandlers/battery.md
+++ b/docs/EasyCommands/blockHandlers/battery.md
@@ -6,10 +6,44 @@ This block handler is all about batteries.  Keep your ships powered and monitor 
 
 Default Primitive Properties:
 * Numeric - Ratio
-* Boolean - Suppy (Overrides Enabled from Terminal Block)
 
 Default Directional Properties
 * Up - Ratio 
+
+## "Enabled" Property
+* Primitive Type: Bool
+* Keywords: ```enable, enabled```
+* Inverse Keywords: ```disable, disabled```
+
+Enables or Disables the given block
+
+```
+#Enable Block
+enable "My Battery"
+set "My Battery" to enabled
+turn on "My Battery"
+
+#Disable Block
+disable "My Battery"
+set "My Battery" to disabled
+turn off "My Battery"
+```
+
+## "Power" Property
+* Primitive Type: Bool
+* Keywords: ```power, powered```
+
+Turns on or off power to the block.  Effectively the same as the Enabled property.
+
+```
+#Turn on
+turn on power to "My Battery"
+power on "My Battery"
+
+#Turn off
+turn off power to "My Battery"
+power off "My Battery"
+```
 
 ## "Supply" Property
 * Primitive Type: Bool

--- a/docs/EasyCommands/blockHandlers/cockpit.md
+++ b/docs/EasyCommands/blockHandlers/cockpit.md
@@ -35,6 +35,22 @@ set "My Cockpit" to disabled
 turn off "My Cockpit"
 ```
 
+## "Power" Property
+* Primitive Type: Bool
+* Keywords: ```power, powered```
+
+Effectively the same as the Enabled property.
+
+```
+#Turn on
+turn on power to "My Cockpit"
+power on "My Cockpit"
+
+#Turn off
+turn off power to "My Cockpit"
+power off "My Cockpit"
+```
+
 ## "Override" Property
 * Primitive Type: Bool
 * Keywords: ```dampener, dampeners, override, overrides, overriden```

--- a/docs/EasyCommands/blockHandlers/parachute.md
+++ b/docs/EasyCommands/blockHandlers/parachute.md
@@ -6,7 +6,6 @@ Reference: [Parachutes](https://spaceengineers.merlinofmines.com/EasyCommands/bl
 * Block Type Group Keywords: ```chutes, parachutes```
 
 Default Primitive Properties:
-* Bool - Open
 * Numeric - Height
 
 Default Directional Properties

--- a/docs/EasyCommands/blockHandlers/remote.md
+++ b/docs/EasyCommands/blockHandlers/remote.md
@@ -7,7 +7,7 @@ Remote Control Blocks can be told where to go and how fast to go there, which ma
 * Block Type Group Keywords: ```remotes, drones, robots```
 
 Default Primitive Properties:
-* Boolean: Auto
+* Bool: Auto (overrides Enabled)
 * Numeric: Velocity
 * Vector: Waypoint
 * List: Waypoints
@@ -15,6 +15,39 @@ Default Primitive Properties:
 Default Directional Properties
 * Up: Velocity
 
+## "Enabled" Property
+* Primitive Type: Bool
+* Keywords: ```enable, enabled```
+* Inverse Keywords: ```disable, disabled```
+
+Gets/Sets whether the given remote control(s) are considered the Main Remote Control (meaning can control the ship).
+
+```
+#Enable Block
+enable "My Remote Control"
+set "My Remote Control" to enabled
+
+#Disable Block
+disable "My Remote Control"
+set "My Remote Control" to disabled
+```
+
+## "Power" Property
+* Primitive Type: Bool
+* Keywords: ```power, powered```
+
+Effectively the same as "Enabled"
+
+```
+#Enable
+turn on power to "My Remote Control"
+power on "My Remote Control"
+
+#Disable
+turn off power to "My Remote Control"
+power off "My Remote Control"
+```
+
 ## "Auto" Property
 * Primitive Type: Bool
 * Keywords: ```auto, autopilot```
@@ -29,18 +62,20 @@ turn on "My Remote Control" autopilot
 set "My Remote Control" to auto
 ```
 
-## "Auto" Property
-* Primitive Type: Bool
-* Keywords: ```auto, autopilot```
-
-Gets/Sets whether autopilot is enabled.  When enabled, Autopilot will begin navigating to its specified waypoint(s) according to it's flight mode.
+This is the default boolean property, so you can also use the following:
 
 ```
-if "My Remote Control" is on autopilot
-  Print "Ship is driving itself"
+#Turn on Autopilot
+turn on "My Remote Control"
+start "My Remote Control"
+resume "My Remote Control"
+tell "My Remote Control" to begin
 
-turn on "My Remote Control" autopilot
-set "My Remote Control" to auto
+#Turn off Autopilot
+turn off "My Remote Control"
+stop "My Remote Control"
+tell "My Remote Control" to stop
+halt "My Remote Control"
 ```
 
 ## "Run" Property

--- a/docs/EasyCommands/blockHandlers/sensor.md
+++ b/docs/EasyCommands/blockHandlers/sensor.md
@@ -5,7 +5,6 @@ This Block Handles Sensors, which you can use to automatically do things when yo
 * Block Type Group Keywords: ```sensors```
 
 Default Primitive Properties:
-* Bool - Triggered
 * Vector - Target
 
 ## "Enabled" Property

--- a/docs/EasyCommands/blockHandlers/tank.md
+++ b/docs/EasyCommands/blockHandlers/tank.md
@@ -77,6 +77,21 @@ Print "Tank Capacity: " + "My Tank" capacity
 
 Gets the percentage that the tank is filled, as a value from 0-1 (0 = empty, 1 = 100% full)
 
+```
+Print "Tank Fill Ratio: " + "My Tank" ratio
+```
+
+## "Level" Property
+* Read-only
+* Primitive Type: Numeric
+* Keywords: ```level, levels```
+
+Gets the approximate level of the tank, in L, by multiplying the tank's capacity by it's current fill ratio.  So if it has as 10000L capacity and is 40% full, would return 4000.
+
+```
+Print "Tank Level: " + "My Tank" level
+```
+
 ## "Auto" Property
 * Primitive Type: Bool
 * Keywords: ```auto, refill```

--- a/docs/EasyCommands/blockHandlers/tank.md
+++ b/docs/EasyCommands/blockHandlers/tank.md
@@ -5,7 +5,6 @@ This Block Handler handles both Oxygen and Hydrogen tanks.  It enables you to ge
 * Block Type Group Keywords: ```tanks```
 
 Default Primitive Properties:
-* Bool - Auto
 * Numeric - Ratio
 
 Default Directional Properties
@@ -49,7 +48,7 @@ power off "My Tank"
 ## "Supply" Property
 * Primitive Type: Bool
 * Keywords: ```supply```
-* Inverse Keywords: ```stockpile, , collect, collecting```
+* Inverse Keywords: ```stockpile, stockpiling, collect, collecting```
 
 Gets/Sets whether the tank is set to stockpile
 

--- a/docs/EasyCommands/cheatsheet.md
+++ b/docs/EasyCommands/cheatsheet.md
@@ -110,7 +110,7 @@ These words are (mostly) ignored when parsing your script, but feel free to use 
 * Strength - ```strength, strengths, force, forces, torque, torques, gravity, gravities```
 * Supply - 
   * ```pressure, pressurize, pressurizing, supply, supplying, generate, generating, discharge, discharging, broadcast, broadcasting, assemble, assembling```
-  * (```stockpile, depressurize, depressurizing, gather, gathering, intake, recharge, recharging, consume, consuming, collect, collecting, disassemble, disassembling```)
+  * (```stockpile, stockpiling, depressurize, depressurizing, gather, gathering, intake, recharge, recharging, consume, consuming, collect, collecting, disassemble, disassembling```)
 * Target (also Waypoint) - ```target, destination, waypoint, coords, coordinates```
 * Target Velocity - ```targetvelocity```
 * Text - ```text, texts, message, messages```


### PR DESCRIPTION
This commit fixes Power/Enable properties and removed several incorrect boolean default properties, including air vents, assemblers, batteries, cockpits, cameras,
gas tanks, parachutes, remote control blocks, and sensors

Also added missing "stockpiling" keywords.

Resolves #114 