### PR TITLE
Programmable Block Improvements

### DIFF
--- a/EasyCommands.Tests/ScriptTests/BlockHandlerTests/ProgramBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/BlockHandlerTests/ProgramBlockTests.cs
@@ -38,7 +38,7 @@ namespace EasyCommands.Tests.ScriptTests {
 
         [TestMethod]
         public void GetTheProgramRunArgument() {
-            using (ScriptTest test = new ScriptTest(@"Print ""Run Argument: "" + the ""test program"" text")) {
+            using (ScriptTest test = new ScriptTest(@"Print ""Run Argument: "" + the ""test program"" argument")) {
                 Mock<IMyProgrammableBlock> mockProgram = new Mock<IMyProgrammableBlock>();
                 test.MockBlocksOfType("test program", mockProgram);
 
@@ -55,10 +55,24 @@ namespace EasyCommands.Tests.ScriptTests {
             using (ScriptTest test = new ScriptTest(@"run the""test program""")) {
                 Mock<IMyProgrammableBlock> mockProgram = new Mock<IMyProgrammableBlock>();
                 test.MockBlocksOfType("test program", mockProgram);
+                mockProgram.Setup(b => b.TerminalRunArgument).Returns("");
 
                 test.RunUntilDone();
 
                 mockProgram.Verify(b => b.TryRun(""));
+            }
+        }
+
+        [TestMethod]
+        public void RunTheProgramUsesDefaultArgument() {
+            using (ScriptTest test = new ScriptTest(@"run the""test program""")) {
+                Mock<IMyProgrammableBlock> mockProgram = new Mock<IMyProgrammableBlock>();
+                test.MockBlocksOfType("test program", mockProgram);
+                mockProgram.Setup(b => b.TerminalRunArgument).Returns("defaultArgument");
+
+                test.RunUntilDone();
+
+                mockProgram.Verify(b => b.TryRun("defaultArgument"));
             }
         }
 

--- a/EasyCommands/BlockHandlers/ProgrammableBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/ProgrammableBlockHandlers.cs
@@ -25,7 +25,7 @@ namespace IngameScript {
                 AddStringHandler(Property.TEXT, block => block.TerminalRunArgument);
                 AddReturnHandlers(Property.RUN, Return.STRING,
                     TypeHandler(StringHandler(b => b.IsRunning.ToString(), (b, v) => b.TryRun(v)), Return.STRING),
-                    TypeHandler(BooleanHandler(b => b.IsRunning, (b, v) => { if (v) b.TryRun(""); else b.Enabled = false; }), Return.BOOLEAN));
+                    TypeHandler(BooleanHandler(b => b.IsRunning, (b, v) => { if (v) b.TryRun(b.TerminalRunArgument); else b.Enabled = false; }), Return.BOOLEAN));
 
                 defaultPropertiesByPrimitive[Return.STRING] = Property.RUN;
             }

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -101,7 +101,7 @@ namespace IngameScript {
             AddPropertyWords(Words("open", "opened"), Property.OPEN);
             AddPropertyWords(Words("close", "closed", "shut"), Property.OPEN, false);
             AddPropertyWords(PluralWords("font"), Property.FONT);
-            AddPropertyWords(PluralWords("text", "message"), Property.TEXT);
+            AddPropertyWords(PluralWords("text", "message", "argument"), Property.TEXT);
             AddPropertyWords(PluralWords("color", "foreground"), Property.COLOR);
             AddPropertyWords(PluralWords("background"), Property.BACKGROUND);
             AddPropertyWords(Words("power", "powered"), Property.POWER);
@@ -267,7 +267,7 @@ namespace IngameScript {
             AddBlockWords(Words("light", "spotlight"), Block.LIGHT);
             AddBlockWords(Words("rotor"), Block.ROTOR);
             AddBlockWords(Words("hinge"), Block.HINGE);
-            AddBlockWords(Words("program"), Block.PROGRAM);
+            AddBlockWords(Words("program", "programmable"), Block.PROGRAM);
             AddBlockWords(Words("timer"), Block.TIMER);
             AddBlockWords(Words("projector"), Block.PROJECTOR);
             AddBlockWords(Words("merge"), Words(), Block.MERGE);

--- a/docs/EasyCommands/blockHandlers/program.md
+++ b/docs/EasyCommands/blockHandlers/program.md
@@ -1,7 +1,7 @@
 ﻿# Programmable Block Handler
 This Block Handler handles Programmable Blocks.  It allows you to get the running state of a given program and also ask it to execute a script.
 
-* Block Type Keywords: ```program```
+* Block Type Keywords: ```program, programmable```
 * Block Type Group Keywords: ```programs```
 
 Default Primitive Properties:
@@ -48,7 +48,7 @@ power off "My Program"
 
 Gets/Sets whether the Program is running.  When retrieving, only Bool is supported.
 
-When setting, if a boolean is set then the program will try to run with no argument ("") when true and disable the block when false.
+When setting, if a boolean is set then the program will try to run with the default terminal argument when true and disable the block when false.
 
 If a string is set, then the program will try to run with the given argument.
 
@@ -81,7 +81,7 @@ when "My Program" is complete
 ## "Text" Property
 * Read-only
 * Primitive Type: String
-* Keywords: ```text```
+* Keywords: ```text, texts, argument, arguments```
 
 Gets the default terminal argument.
 

--- a/docs/EasyCommands/cheatsheet.md
+++ b/docs/EasyCommands/cheatsheet.md
@@ -50,7 +50,7 @@ These words are (mostly) ignored when parsing your script, but feel free to use 
 * O2/H2 Generator - ```generator```, ```generators```
 * Ore Detector - ```detector```, ```detectors```
 * Parachute - ```chute, parachute```, ```chutes, parachutes```
-* Programmable Block - ```program```, ```programs```
+* Programmable Block - ```program, programmable```, ```programs```
 * Piston - ```piston```, ```pistons```
 * Projector - ```projector```, ```projectors``` 
 * Reactor - ```reactor```, ```reactors```
@@ -113,7 +113,7 @@ These words are (mostly) ignored when parsing your script, but feel free to use 
   * (```stockpile, depressurize, depressurizing, gather, gathering, intake, recharge, recharging, consume, consuming, collect, collecting, disassemble, disassembling```)
 * Target (also Waypoint) - ```target, destination, waypoint, coords, coordinates```
 * Target Velocity - ```targetvelocity```
-* Text - ```text, texts, message, messages```
+* Text - ```text, texts, message, messages, argument, arguments```
 * Trigger - ```trigger, triggered, detect, detected, trip, tripped, deploy, deployed, shoot, shooting, shot, detonate```
 * Velocity - ```velocity, velocities, speed, speeds, rate, rates, pace, paces```
 * Volume (also Output & Intensity) - ```volume, volumes, output, outputs, intensity, intensities```


### PR DESCRIPTION
This commit adds "programmable" as a block word for Programmable Blocks, adds "argument" as a text property keyword, and defaults "Run" to use the default terminal
argument instead of ""