### PR TITLE
Gyro Block Improvements

### DIFF
--- a/EasyCommands.Tests/ScriptTests/BlockHandlerTests/GyroscopeBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/BlockHandlerTests/GyroscopeBlockTests.cs
@@ -3,16 +3,14 @@ using System;
 using Moq;
 using Sandbox.ModAPI.Ingame;
 using VRageMath;
+using static EasyCommands.Tests.ScriptTests.MockEntityUtility;
 
 namespace EasyCommands.Tests.ScriptTests {
     [TestClass]
     public class GyroscopeBlockTests {
         [TestMethod]
         public void DisableGyroscopeAuto() {
-            String script = @"
-set the ""test gyro"" auto to false
-";
-            using (var test = new ScriptTest(script)) {
+            using (var test = new ScriptTest(@"set the ""test gyro"" auto to false")) {
                 var mockGyro = new Mock<IMyGyro>();
 
                 test.MockBlocksOfType("test gyro", mockGyro);
@@ -23,11 +21,8 @@ set the ""test gyro"" auto to false
         }
 
         [TestMethod]
-        public void EnableGyroscopeOverrides() {
-            String script = @"
-override ""test gyro""
-";
-            using (var test = new ScriptTest(script)) {
+        public void TurnOnTheGyroscopeOverrides() {
+            using (var test = new ScriptTest(@"turn on the""test gyro"" overrides")) {
                 var mockGyro = new Mock<IMyGyro>();
 
                 test.MockBlocksOfType("test gyro", mockGyro);
@@ -38,11 +33,33 @@ override ""test gyro""
         }
 
         [TestMethod]
-        public void SetGyroscopePowerLevel() {
-            String script = @"
-set the ""test gyro"" limit to 0.5
-";
-            using (var test = new ScriptTest(script)) {
+        public void TurnOffTheGyroscopeRotation() {
+            using (var test = new ScriptTest(@"turn off the""test gyro"" rotation")) {
+                var mockGyro = new Mock<IMyGyro>();
+
+                test.MockBlocksOfType("test gyro", mockGyro);
+                test.RunUntilDone();
+
+                mockGyro.VerifySet(b => b.GyroOverride = false);
+            }
+        }
+
+        [TestMethod]
+        public void GetGyroscopePower() {
+            using (var test = new ScriptTest(@"Print ""Power: "" + the ""test gyro"" power")) {
+                var mockGyro = new Mock<IMyGyro>();
+                test.MockBlocksOfType("test gyro", mockGyro);
+                mockGyro.Setup(b => b.GyroPower).Returns(0.5f);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Power: 0.5", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void SetGyroscopePower() {
+            using (var test = new ScriptTest(@"set the ""test gyro"" power to 0.5")) {
                 var mockGyro = new Mock<IMyGyro>();
 
                 test.MockBlocksOfType("test gyro", mockGyro);
@@ -53,92 +70,196 @@ set the ""test gyro"" limit to 0.5
         }
 
         [TestMethod]
-        public void SetGyroscopePitch() {
-            String script = @"
-set the ""test gyro"" upwards roll to 0.5
-";
-            using (var test = new ScriptTest(script)) {
+        public void SetGyroscopeLimit() {
+            using (var test = new ScriptTest(@"set the ""test gyro"" limit to 0.5")) {
                 var mockGyro = new Mock<IMyGyro>();
 
                 test.MockBlocksOfType("test gyro", mockGyro);
                 test.RunUntilDone();
 
-                mockGyro.VerifySet(b => b.Pitch = 0.5f);
+                mockGyro.VerifySet(b => b.GyroPower = 0.5f);
+            }
+        }
+
+        [TestMethod]
+        public void GetGyroscopeRotationVector() {
+            using (var test = new ScriptTest(@"Print ""Rotation: "" + the ""test gyro"" rotation")) {
+                var mockGyro = new Mock<IMyGyro>();
+                MockGetProperty(mockGyro, "Pitch", 1f);
+                MockGetProperty(mockGyro, "Yaw", 2f);
+                MockGetProperty(mockGyro, "Roll", 3f);
+                test.MockBlocksOfType("test gyro", mockGyro);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Rotation: 1:2:3", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void SetGyroscopeRotationVector() {
+            using (var test = new ScriptTest(@"set the ""test gyro"" rotation to 1:2:3")) {
+                var mockGyro = new Mock<IMyGyro>();
+                var mockPitch = MockProperty<IMyGyro, float>(mockGyro, "Pitch");
+                var mockYaw = MockProperty<IMyGyro, float>(mockGyro, "Yaw");
+                var mockRoll = MockProperty<IMyGyro, float>(mockGyro, "Roll");
+                test.MockBlocksOfType("test gyro", mockGyro);
+
+                test.RunUntilDone();
+
+                mockPitch.Verify(p => p.SetValue(mockGyro.Object, 1f));
+                mockYaw.Verify(p => p.SetValue(mockGyro.Object, 2f));
+                mockRoll.Verify(p => p.SetValue(mockGyro.Object, 3f));
+            }
+        }
+
+        [TestMethod]
+        public void GetGyroscopePitch() {
+            using (var test = new ScriptTest(@"Print ""Pitch: "" + the ""test gyro"" upwards rotation")) {
+                var mockGyro = new Mock<IMyGyro>();
+                MockGetProperty(mockGyro, "Pitch", 5f);
+                test.MockBlocksOfType("test gyro", mockGyro);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Pitch: 5", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void SetGyroscopePitch() {
+            using (var test = new ScriptTest(@"set the ""test gyro"" upwards rotation to 10")) {
+                var mockGyro = new Mock<IMyGyro>();
+                var mockPitch = MockProperty<IMyGyro, float>(mockGyro, "Pitch");
+                test.MockBlocksOfType("test gyro", mockGyro);
+                test.RunUntilDone();
+
+                mockPitch.Verify(p => p.SetValue(mockGyro.Object, 10f));
+            }
+        }
+
+        [TestMethod]
+        public void GetGyroscopeInversePitch() {
+            using (var test = new ScriptTest(@"Print ""Pitch: "" + the ""test gyro"" downwards rotation")) {
+                var mockGyro = new Mock<IMyGyro>();
+                MockGetProperty(mockGyro, "Pitch", 5f);
+                test.MockBlocksOfType("test gyro", mockGyro);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Pitch: -5", test.Logger[0]);
             }
         }
 
         [TestMethod]
         public void SetGyroscopeInversePitch() {
-            String script = @"
-set the ""test gyro"" downwards roll to 0.5
-";
-            using (var test = new ScriptTest(script)) {
+            using (var test = new ScriptTest(@"set the ""test gyro"" downwards rotation to 10")) {
                 var mockGyro = new Mock<IMyGyro>();
-
+                var mockPitch = MockProperty<IMyGyro, float>(mockGyro, "Pitch");
                 test.MockBlocksOfType("test gyro", mockGyro);
                 test.RunUntilDone();
 
-                mockGyro.VerifySet(b => b.Pitch = -0.5f);
+                mockPitch.Verify(p => p.SetValue(mockGyro.Object, -10f));
+            }
+        }
+
+        [TestMethod]
+        public void GetGyroscopeYaw() {
+            using (var test = new ScriptTest(@"Print ""Yaw: "" + the ""test gyro"" right rotation")) {
+                var mockGyro = new Mock<IMyGyro>();
+                MockGetProperty(mockGyro, "Yaw", 5f);
+                test.MockBlocksOfType("test gyro", mockGyro);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Yaw: 5", test.Logger[0]);
             }
         }
 
         [TestMethod]
         public void SetGyroscopeYaw() {
-            String script = @"
-set the ""test gyro"" right roll to 0.5
-";
-            using (var test = new ScriptTest(script)) {
+            using (var test = new ScriptTest(@"set the ""test gyro"" right rotation to 10")) {
                 var mockGyro = new Mock<IMyGyro>();
-
+                var mockYaw = MockProperty<IMyGyro, float>(mockGyro, "Yaw");
                 test.MockBlocksOfType("test gyro", mockGyro);
                 test.RunUntilDone();
 
-                mockGyro.VerifySet(b => b.Yaw = 0.5f);
+                mockYaw.Verify(p => p.SetValue(mockGyro.Object, 10f));
+            }
+        }
+
+        [TestMethod]
+        public void GetGyroscopeInverseYaw() {
+            using (var test = new ScriptTest(@"Print ""Yaw: "" + the ""test gyro"" left rotation")) {
+                var mockGyro = new Mock<IMyGyro>();
+                MockGetProperty(mockGyro, "Yaw", 5f);
+                test.MockBlocksOfType("test gyro", mockGyro);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Yaw: -5", test.Logger[0]);
             }
         }
 
         [TestMethod]
         public void SetGyroscopeInverseYaw() {
-            String script = @"
-set the ""test gyro"" left roll to 0.5
-";
-            using (var test = new ScriptTest(script)) {
+            using (var test = new ScriptTest(@"set the ""test gyro"" left rotation to 10")) {
                 var mockGyro = new Mock<IMyGyro>();
-
+                var mockYaw = MockProperty<IMyGyro, float>(mockGyro, "Yaw");
                 test.MockBlocksOfType("test gyro", mockGyro);
                 test.RunUntilDone();
 
-                mockGyro.VerifySet(b => b.Yaw = -0.5f);
+                mockYaw.Verify(p => p.SetValue(mockGyro.Object, -10f));
+            }
+        }
+
+        [TestMethod]
+        public void GetGyroscopeRoll() {
+            using (var test = new ScriptTest(@"Print ""Roll: "" + the ""test gyro"" clockwise rotation")) {
+                var mockGyro = new Mock<IMyGyro>();
+                MockGetProperty(mockGyro, "Roll", 5f);
+                test.MockBlocksOfType("test gyro", mockGyro);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Roll: 5", test.Logger[0]);
             }
         }
 
         [TestMethod]
         public void SetGyroscopeRoll() {
-            String script = @"
-set the ""test gyro"" clockwise roll to 0.5
-";
-            using (var test = new ScriptTest(script)) {
+            using (var test = new ScriptTest(@"set the ""test gyro"" clockwise rotation to 10")) {
                 var mockGyro = new Mock<IMyGyro>();
-
+                var mockRoll = MockProperty<IMyGyro, float>(mockGyro, "Roll");
                 test.MockBlocksOfType("test gyro", mockGyro);
                 test.RunUntilDone();
 
-                mockGyro.VerifySet(b => b.Roll = 0.5f);
+                mockRoll.Verify(p => p.SetValue(mockGyro.Object, 10f));
+            }
+        }
+
+        [TestMethod]
+        public void GetGyroscopeInverseRoll() {
+            using (var test = new ScriptTest(@"Print ""Roll: "" + the ""test gyro"" counter rotation")) {
+                var mockGyro = new Mock<IMyGyro>();
+                MockGetProperty(mockGyro, "Roll", 5f);
+                test.MockBlocksOfType("test gyro", mockGyro);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Roll: -5", test.Logger[0]);
             }
         }
 
         [TestMethod]
         public void SetGyroscopeInverseRoll() {
-            String script = @"
-set the ""test gyro"" counterclock roll to 0.5
-";
-            using (var test = new ScriptTest(script)) {
+            using (var test = new ScriptTest(@"set the ""test gyro"" counter rotation to 10")) {
                 var mockGyro = new Mock<IMyGyro>();
-
+                var mockRoll = MockProperty<IMyGyro, float>(mockGyro, "Roll");
                 test.MockBlocksOfType("test gyro", mockGyro);
                 test.RunUntilDone();
 
-                mockGyro.VerifySet(b => b.Roll = -0.5f);
+                mockRoll.Verify(p => p.SetValue(mockGyro.Object, -10f));
             }
         }
     }

--- a/EasyCommands/BlockHandlers/BlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/BlockHandlers.cs
@@ -34,7 +34,7 @@ namespace IngameScript {
                 { Block.GRAVITY_SPHERE, new SphericalGravityGeneratorBlockHandler() },
                 { Block.GRINDER, new FunctionalBlockHandler<IMyShipGrinder>() },
                 { Block.GUN, new GunBlockHandler<IMyUserControllableGun>() },
-                { Block.GYROSCOPE, new GyroscopeBlockHandler() },
+                { Block.GYROSCOPE, new GyroscopeBlockHandler<IMyGyro>() },
                 { Block.HINGE, new RotorBlockHandler(IsHinge) },
                 { Block.JUMPDRIVE, new JumpDriveBlockHandler() },
                 { Block.LASER_ANTENNA, new LaserAntennaBlockHandler() },

--- a/EasyCommands/BlockHandlers/GyroscopeBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/GyroscopeBlockHandlers.cs
@@ -36,12 +36,12 @@ namespace IngameScript {
                             }), Return.VECTOR),
                             TypeHandler(BooleanHandler(b => b.GyroOverride, (b, v) => b.GyroOverride = v), Return.BOOLEAN))
                         , Direction.NONE),
-                        TypeHandler(NumericHandler(GetPitch, SetPitch, 10), Direction.UP),
-                        TypeHandler(NumericHandler(b => -GetPitch(b), (b, v) => SetPitch(b, -v)), Direction.DOWN),
-                        TypeHandler(NumericHandler(b => -GetYaw(b), (b, v) => SetYaw(b, -v)), Direction.LEFT),
-                        TypeHandler(NumericHandler(GetYaw, SetYaw), Direction.RIGHT),
-                        TypeHandler(NumericHandler(GetRoll, SetRoll), Direction.CLOCKWISE),
-                        TypeHandler(NumericHandler(b => -GetRoll(b), (b, v) => SetRoll(b, -v)), Direction.COUNTERCLOCKWISE));
+                        TypeHandler(NumericHandler(GetPitch, SetPitch, 5), Direction.UP),
+                        TypeHandler(NumericHandler(b => -GetPitch(b), (b, v) => SetPitch(b, -v), 5), Direction.DOWN),
+                        TypeHandler(NumericHandler(b => -GetYaw(b), (b, v) => SetYaw(b, -v), 5), Direction.LEFT),
+                        TypeHandler(NumericHandler(GetYaw, SetYaw, 5), Direction.RIGHT),
+                        TypeHandler(NumericHandler(GetRoll, SetRoll, 5), Direction.CLOCKWISE),
+                        TypeHandler(NumericHandler(b => -GetRoll(b), (b, v) => SetRoll(b, -v), 5), Direction.COUNTERCLOCKWISE));
 
                 AddPropertyHandler(Property.OVERRIDE, overrideHandler);
                 AddPropertyHandler(Property.ROLL_INPUT, overrideHandler);

--- a/docs/EasyCommands/blockHandlers/gyroscope.md
+++ b/docs/EasyCommands/blockHandlers/gyroscope.md
@@ -27,19 +27,15 @@ turn off "My Gyro"
 ```
 
 ## "Power" Property
-* Primitive Type: Bool
+* Primitive Type: Numeric
 * Keywords: ```power, powered```
 
-Turns on or off power to the block.  Effectively the same as the Enabled property.
+Gets/Sets the Gyro Power limit.  Values are between 0 - 1, with 1 = 100% Power.
 
 ```
-#Turn on
-turn on power to "My Gyro"
-power on "My Gyro"
+Print "Gyro Power: " + "My Gyro" power
 
-#Turn off
-turn off "My Gyro"
-power off "My Gyro"
+set "My Gyro" power to 0.5
 ```
 
 ## "Auto" Property
@@ -55,34 +51,32 @@ if "My Gyro" is on auto
 set "My Gyro" to auto
 ```
 
-## "Override" Property
-* Primitive Type: Bool
-* Keywords: ```override, overrides, overridden```
-
-Effectively the opposite of Auto.  When set, will turn on Gyro Overrides.
-
-```
-if "My Gyro" is overridden
-  Print `Now I'm in control!`
-
-#Turn on overrides
-override "My Gyro"
-```
-
 ## "Limit" Property
 * Primitive Type: Numeric
 * Keywords: ```limit, limits```
 
 Gets/Sets the Gyro Power limit.  Values are between 0 - 1, with 1 = 100% Power.
 
+```
+Print "Gyro Power: " + "My Gyro" limit
+
+set "My Gyro" limit to 0.5
+```
+
 ## "Roll" Property
-* Primitive Type: Numeric
+* Primitive Type: Vector / Numeric / Bool
 * Keywords: ```roll, rollInput, rotation```
 * Supports Directions (Left, Right, Up, Down, Clockwise, CounterClockwise)
 
-Gets/Sets the Gyro override in the given direction, in RPM.  If no direction is given, Up is used.
-
 This is useful for automatically adjusting your orientation based on some other inputs.
+
+If a direction is given, expects a Numeric and Gets/Sets the Gyro override in the given direction, in RPM.  
+
+If no direction is given and a boolean is given, Gets/Sets whether Gyro Overrides are enabled.
+
+If no direction is given and a vector is given, Gets/Sets the Gyro Overrides (Yaw:Pitch:Roll).
+
+If no direction is given and no type is given, vector is assumed.
 
 Note that Gyro overrides directions are based on the Gyro's orientation, not the cockpit's orientation.
 
@@ -101,7 +95,7 @@ set "My Gyro" clockwise roll to 3
 * Keywords: ```input, inputs```
 * Supports Directions (Left, Right, Up, Down, Clockwise, CounterClockwise)
 
-Same as Roll Property. Gets/Sets the Gyro override in the given direction.  Up is the default if no direction is passed.
+Same as Roll Property.
 
 ```
 Print "Gyro Left Rotation: " + "My Gyro" left input
@@ -111,4 +105,25 @@ set "My Gyro" left input to 2
 
 #3 RPM clockwise
 set "My Gyro" clockwise input to 3
+```
+
+
+## "Override" Property
+* Primitive Type: Bool
+* Keywords: ```override, overrides, overridden```
+
+Same as Roll Property.
+
+```
+if "My Gyro" is overridden
+  Print `Now I'm in control!`
+
+#Turn on overrides
+override "My Gyro"
+
+#Yaw Override 5 RPM
+set "My Gyro" left override to 5
+
+#Print the Gyro Overrides, as a vector
+Print "Gyro Overrides: " + "My Gyro" overrides
 ```


### PR DESCRIPTION
This commit fixes Gyro Overrides support to propertly use RPM, vs a weird % that didn't really work right.

It also extends "overrides" support to include vector, numeric and boolean.

Also, the Power property now controls Gyro power.

This PR resolves #108 