### PR TITLE
Added Split and Join Operations

### DIFF
--- a/EasyCommands.Tests/ParameterParsingTests/OperatorParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/OperatorParameterProcessorTests.cs
@@ -803,5 +803,49 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             Assert.AreEqual(Return.BOOLEAN, value.returnType);
             Assert.AreEqual(true, value.value);
         }
+
+        [TestMethod]
+        public void SplitStringBySubString() {
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to \"My Value\" split \" \"");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
+            Primitive value = assignment.variable.GetValue();
+            Assert.AreEqual(Return.LIST, value.returnType);
+            Assert.AreEqual("[My,Value]", CastString(value));
+        }
+
+        [TestMethod]
+        public void SplitStringByNewLine() {
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to \"My\nValue\" split \"\\n\"");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
+            Primitive value = assignment.variable.GetValue();
+            Assert.AreEqual(Return.LIST, value.returnType);
+            Assert.AreEqual("[My,Value]", CastString(value));
+        }
+
+        [TestMethod]
+        public void JoinListByString() {
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to [1,2,3] joined \", \"");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
+            Primitive value = assignment.variable.GetValue();
+            Assert.AreEqual(Return.STRING, value.returnType);
+            Assert.AreEqual("1, 2, 3", CastString(value));
+        }
+
+        [TestMethod]
+        public void JoinListByNewLine() {
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to [1,2,3] joined \"\\n\"");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
+            Primitive value = assignment.variable.GetValue();
+            Assert.AreEqual(Return.STRING, value.returnType);
+            Assert.AreEqual("1\n2\n3", value.value);
+        }
     }
 }

--- a/EasyCommands.Tests/ScriptTests/BlockHandlerTests/TextSurfaceBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/BlockHandlerTests/TextSurfaceBlockTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Text;
 using Moq;
 using Sandbox.ModAPI.Ingame;
 using VRageMath;
@@ -59,7 +60,10 @@ namespace EasyCommands.Tests.ScriptTests {
             using (ScriptTest test = new ScriptTest(script)) {
                 var mockTextPanel = new Mock<IMyTextPanel>();
                 test.MockBlocksOfType("text panel", mockTextPanel);
-                mockTextPanel.Setup(b => b.GetText()).Returns("Hello World!");
+                StringBuilder stringBuilder = new StringBuilder();
+                mockTextPanel.Setup(b => b.ReadText(It.IsAny<StringBuilder>(), false))
+                    .Callback<StringBuilder, bool>((builder, append) => builder.Append("Hello World!"));
+
                 test.RunUntilDone();
 
                 Assert.AreEqual("Text: Hello World!", test.Logger[0]);
@@ -135,7 +139,8 @@ increase the ""text panel"" display text by ""\nThis is my life""
 
                 mockTextPanel.Verify(b => b.WriteText("Hello World", false));
 
-                mockTextPanel.Setup(b => b.GetText()).Returns("Hello World");
+                mockTextPanel.Setup(b => b.ReadText(It.IsAny<StringBuilder>(), false))
+                    .Callback<StringBuilder, bool>((builder, append) => builder.Append("Hello World"));
 
                 test.RunOnce();
 

--- a/EasyCommands/BlockHandlers/TextSurfaceHandlers.cs
+++ b/EasyCommands/BlockHandlers/TextSurfaceHandlers.cs
@@ -24,8 +24,9 @@ namespace IngameScript {
                 var fontSizeHandler = NumericHandler(b => b.FontSize, (b, v) => b.FontSize = v, 0.5f);
                 var fontColorHandler = ColorHandler(b => b.ContentType == ContentType.SCRIPT ? b.ScriptForegroundColor : b.FontColor, (b, v) => { if (b.ContentType == ContentType.SCRIPT) b.ScriptForegroundColor = v; else b.FontColor = v; });
 
+                AddStringHandler(Property.NAME, b => Name(b));
                 AddBooleanHandler(Property.ENABLE, b => b.ContentType != ContentType.NONE, (b, v) => b.ContentType = v ? ContentType.TEXT_AND_IMAGE : ContentType.NONE);
-                AddStringHandler(Property.TEXT, b => b.GetText(), (b, v) => { b.ContentType = ContentType.TEXT_AND_IMAGE; b.WriteText(v); });
+                AddStringHandler(Property.TEXT, b => { var builder = new StringBuilder(); b.ReadText(builder); return builder.ToString(); }, (b, v) => { b.ContentType = ContentType.TEXT_AND_IMAGE; b.WriteText(v); });
                 AddStringHandler(Property.MEDIA, b => b.CurrentlyShownImage ?? "", (b,v) => SetImages(b,CastList(ResolvePrimitive(v))));
                 AddStringHandler(Property.RUN, b => b.Script ?? "", (b, v) => { b.ContentType = ContentType.SCRIPT; b.Script = v; });
                 AddNumericHandler(Property.OFFSET, b => b.TextPadding, (b, v) => b.TextPadding = v, 1);

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -92,8 +92,8 @@ namespace IngameScript {
             AddPropertyWords(AllWords(PluralWords("height", "length", "level", "size", "period", "scale"), Words("weight", "mass")), Property.LEVEL);
             AddPropertyWords(PluralWords("angle"), Property.ANGLE);
             AddPropertyWords(AllWords(PluralWords("speed", "rate", "pace"), Words("velocity", "velocities")), Property.VELOCITY);
-            AddPropertyWords(Words("connect", "join", "attach", "connected", "joined", "attached", "dock", "docked", "docking"), Property.CONNECTED);
-            AddPropertyWords(Words("disconnect", "separate", "detach", "disconnected", "separated", "detached", "undock", "undocked"), Property.CONNECTED, false);
+            AddPropertyWords(Words("connect", "attach", "connected", "attached", "dock", "docked", "docking"), Property.CONNECTED);
+            AddPropertyWords(Words("disconnect", "detach", "disconnected", "detached", "undock", "undocked"), Property.CONNECTED, false);
             AddPropertyWords(Words("lock", "locked", "freeze", "frozen", "brake", "braking", "handbrake", "permanent"), Property.LOCKED);
             AddPropertyWords(Words("unlock", "unlocked", "unfreeze"), Property.LOCKED, false);
             AddPropertyWords(Words("run", "running", "execute", "executing", "script"), Property.RUN);
@@ -224,6 +224,8 @@ namespace IngameScript {
             AddTier1OperationWords(Words("divide", "/"), BiOperand.DIVIDE);
             AddTier1OperationWords(Words("mod", "%"), BiOperand.MOD);
             AddTier1OperationWords(Words("pow", "^", "xor"), BiOperand.EXPONENT);
+            AddTier1OperationWords(Words("split", "separate", "separated"), BiOperand.SPLIT);
+            AddTier1OperationWords(Words("join", "joined"), BiOperand.JOIN);
 
             AddTier2OperationWords(Words("plus", "+"), BiOperand.ADD);
             AddTier2OperationWords(Words("minus"), BiOperand.SUBTRACT);

--- a/EasyCommands/Common/Operations.cs
+++ b/EasyCommands/Common/Operations.cs
@@ -72,6 +72,7 @@ namespace IngameScript {
                 if (a > b) range = range.Reverse();
                 return new KeyedList(range.ToArray());
             });
+            AddBiOperation<string, string>(BiOperand.SPLIT, (a, b) => new KeyedList(a.Split(NewList(CastString(ResolvePrimitive(b))).ToArray(), StringSplitOptions.None).Select(GetStaticVariable).ToArray()));
             AddUniOperation<KeyedList>(UniOperand.KEYS, a => a.Keys());
             AddUniOperation<KeyedList>(UniOperand.VALUES, a => a.Values());
             AddUniOperation<KeyedList>(UniOperand.REVERSE, a => new KeyedList(a.keyedValues.Select(b => b).Reverse().ToArray()));
@@ -128,6 +129,7 @@ namespace IngameScript {
             AddBiOperation<string, string>(BiOperand.MOD, (a, b) => a.Replace(b, ""));
             AddBiOperation<string, float>(BiOperand.SUBTRACT, (a, b) => b >= a.Length ? "" : a.Substring(0, (int)(a.Length - b)));
             AddBiOperation<object, string>(BiOperand.CAST, (a, b) => castMap[b](ResolvePrimitive(a)));
+            AddBiOperation<KeyedList, string>(BiOperand.JOIN, (a, b) => string.Join(CastString(ResolvePrimitive(b)), a.keyedValues.Select(v => CastString(v.GetValue()))));
 
             //Vector
             AddUniOperation<Vector3D>(UniOperand.REVERSE, a => -a);

--- a/EasyCommands/Common/Types.cs
+++ b/EasyCommands/Common/Types.cs
@@ -29,8 +29,8 @@ namespace IngameScript {
         public enum Direction { UP, DOWN, LEFT, RIGHT, FORWARD, BACKWARD, CLOCKWISE, COUNTERCLOCKWISE, NONE }
         public enum ProgramState { RUNNING, STOPPED, COMPLETE, PAUSED }
         public enum Return { NUMERIC, BOOLEAN, STRING, VECTOR, COLOR, LIST, DEFAULT }
-        public enum BiOperand { ADD, SUBTRACT, MULTIPLY, DIVIDE, MOD, AND, OR, COMPARE, DOT, EXPONENT, RANGE, CAST, CONTAINS };
-        public enum UniOperand { REVERSE, ABS, SQRT, SIN, COS, TAN, ASIN, ACOS, ATAN, ROUND, KEYS, VALUES, TICKS, SORT, LN };
+        public enum BiOperand { ADD, SUBTRACT, MULTIPLY, DIVIDE, MOD, AND, OR, COMPARE, DOT, EXPONENT, RANGE, CAST, CONTAINS, SPLIT, JOIN };
+        public enum UniOperand { REVERSE, ABS, SQRT, SIN, COS, TAN, ASIN, ACOS, ATAN, ROUND, KEYS, VALUES, TICKS, SORT, LN};
         public enum AggregationMode {ANY, ALL, NONE }
     }
 }

--- a/docs/EasyCommands/blockHandlers/connector.md
+++ b/docs/EasyCommands/blockHandlers/connector.md
@@ -44,8 +44,8 @@ power off "My Connector"
 
 ## "Connect" Property
 * Primitive Type: Bool
-* Keywords: ```connect, connected, attach, attached, join, joined, dock, docked```
-* Inverse Keywords: ```disconnect, disconnectd, separate, separated, detach, detached, undock, undocked```
+* Keywords: ```connect, connected, attach, attached, dock, docked```
+* Inverse Keywords: ```disconnect, disconnectd, detach, detached, undock, undocked```
 
 Gets/Sets whether the connector is connected.  A connector is connected if it's Connector status is "Connected".
 

--- a/docs/EasyCommands/blockHandlers/display.md
+++ b/docs/EasyCommands/blockHandlers/display.md
@@ -30,6 +30,7 @@ Print "Display names: " + "My Programmabl Block" display names
 ```
 
 ## "Name" Property
+* Read-only
 * Primitive Type: Bool
 * Keywords: ```name, label```
 

--- a/docs/EasyCommands/blockHandlers/landingGear.md
+++ b/docs/EasyCommands/blockHandlers/landingGear.md
@@ -60,8 +60,8 @@ unlock "My Landing Gear"
 
 ## "Connect" Property
 * Primitive Type: Bool
-* Keywords: ```connect, connected, attach, attached, dock, docked, join, joined```
-* Inverse Keywords: ```disconnect, disconnected, detach, detached, undock, undocked, separate, separated```
+* Keywords: ```connect, connected, attach, attached, dock, docked```
+* Inverse Keywords: ```disconnect, disconnected, detach, detached, undock, undocked```
 
 Same as Locked. Gets/Sets whether the Landing Gear / Magnet is locked. When setting, only attempts to lock once.  If set to a false value, will disconnect.
 

--- a/docs/EasyCommands/blockHandlers/laserAntenna.md
+++ b/docs/EasyCommands/blockHandlers/laserAntenna.md
@@ -99,8 +99,8 @@ lock "My Laser"
 
 ## "Connected" Property
 * Primitive Type: Bool
-* Keywords: ```connect, connected, join, joined, attach, attached```
-* Inverse Keywords: ```disconnect, disconnected, separate, separated, detach, detached```
+* Keywords: ```connect, connected, attach, attached```
+* Inverse Keywords: ```disconnect, disconnected, detach, detached```
 
 Get/Sets whether the laser is currently connected.  When reading, will return whether the Laser's status is Connected.  When updating, will attempt to connect to the laser antenna's target coordinates if the passed in Bool is true.
 

--- a/docs/EasyCommands/blockHandlers/merge.md
+++ b/docs/EasyCommands/blockHandlers/merge.md
@@ -67,8 +67,8 @@ unlock "My Merge Block"
 
 ## "Connected" Property
 * Primitive Type: Bool
-* Keywords: ```connected, attached, docked, joined```
-* Inverse Keywords: ```disconnected, detached, undocked, separated```
+* Keywords: ```connected, attached, docked```
+* Inverse Keywords: ```disconnected, detached, undocked```
 
 Same as Locked.  Returns whether the merge block is currently connected to another merge block.  This property is read-only.  When set, this property enables or disables the merge block (the only way to connect/disconnect).
 

--- a/docs/EasyCommands/cheatsheet.md
+++ b/docs/EasyCommands/cheatsheet.md
@@ -80,8 +80,8 @@ These words are (mostly) ignored when parsing your script, but feel free to use 
 * Color - ```color, foreground```
 * Complete - ```done, ready, complete, finished, built, finish, pressurized, depressurized```
 * Connected -
-  * ```connect, connected, join, joined, attach, attached, dock, docked, docking```
-  * (```disconnect, disconnected, separate, separated, detach, detached, undock, undocked```)
+  * ```connect, connected, attach, attached, dock, docked, docking```
+  * (```disconnect, disconnected, detach, detached, undock, undocked```)
 * Countdown - ```countdown, countdowns```
 * Direction - ```direction, directions```
 * Enable - ```enable, enabled, arm, armed```, (```disable, disabled, disarm, disarmed```)
@@ -207,8 +207,10 @@ These properties require a Variable value as part of the property
 * Divide - ```divide, /```
 * Modulus - ```mod, %```
 * Exponent - ```pow, ^, xor``` (also used for Xor and Angle Between Operations)
+* Join - ```join, joined```
 * Natural Logarithm - ```ln``` 
 * Add - ```+, plus```
+* Split - ```split, separate, separated```
 * Subtract - ```-, minus```
 * Dot Product - ```dot, .```
 * Ternary - ```?, :```

--- a/docs/EasyCommands/operations.md
+++ b/docs/EasyCommands/operations.md
@@ -43,7 +43,7 @@ All UniOperand Operations are evaluated before BiOperatnd Operations.
 
 Here are the tiers for BiOperand Operations:
 * Tier 0 BiOperand Operations: ```.```
-* Tier 1 BiOperand Operations: ```*, /, %, ^```
+* Tier 1 BiOperand Operations: ```*, /, %, ^, split, join```
 * Tier 2 BiOperand Operations: ```+, -```
 * Tier 3 BiOperand Operations: ```.., cast```
 
@@ -363,6 +363,21 @@ Keywords: ```^, pow, xor```
 * **(Number, Number)**: Raises the first number to the power of the second number
 * **(Vector, Vector)**: Returns the angle (in degrees) between the two given vectors (get it? ```^```)
 
+### Join
+Joins a given list by the given string separator by casting each list value to a string and then joining them together using the given separator.
+
+Keywords: ```join, joined```
+
+```
+set myOutput to [1,2,3] joined ", "
+#1, 2, 3
+```
+
+```
+#Line Separated Values
+set myOutput to [1,2,3] joined "\n"
+```
+
 ### Modulus
 Behavior varies based on input types.
 
@@ -405,6 +420,21 @@ set myList to [0..2]
 set myList to ["one", "two", "three"]
 for each i in 0..count of myList[] - 1
   Print "myList[" + i + "]: " + myList[i]
+```
+
+### Split
+Splits the given string by the given string separator.  The result is a List containing the separated values.
+
+Keywords: ```split, separate, separated```
+
+```
+set myOutput to "My Values" split " "
+#[My,Values]
+```
+
+```
+#Get Display Output Lines
+set myOutput to my display[0] text split "\n"
 ```
 
 ### Subtraction


### PR DESCRIPTION
This commit also fixes a couple issues with Text Surfaces.  First, the Name property was missing.  Second, "GetText()" wasn't working.  Replaced with ReadText().

This commit also re-purposes "split, join, joined, separate, separated" to the new operations and removes them from the connected property.

This commit resolves #130 