### PR TITLE
Added missing default boolean property to Display block

### DIFF
--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/TextSurfaceBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/TextSurfaceBlockTests.cs
@@ -12,6 +12,20 @@ namespace EasyCommands.Tests.ScriptTests {
     [TestClass]
     public class TextSurfaceBlockTests {
         [TestMethod]
+        public void TurnOnTextPanel() {
+            String script = @"turn on the ""text panel"" display";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockTextPanel = new Mock<IMyTextPanel>();
+                test.MockBlocksOfType("text panel", mockTextPanel);
+
+                test.RunUntilDone();
+
+                mockTextPanel.VerifySet(b => b.ContentType = ContentType.TEXT_AND_IMAGE);
+            }
+        }
+
+        [TestMethod]
         public void EnableTextPanel() {
             String script = @"enable the ""text panel"" display";
 
@@ -22,6 +36,20 @@ namespace EasyCommands.Tests.ScriptTests {
                 test.RunUntilDone();
 
                 mockTextPanel.VerifySet(b => b.ContentType = ContentType.TEXT_AND_IMAGE);
+            }
+        }
+
+        [TestMethod]
+        public void TurnOffTextPanel() {
+            String script = @"turn off the ""text panel"" display";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockTextPanel = new Mock<IMyTextPanel>();
+                test.MockBlocksOfType("text panel", mockTextPanel);
+
+                test.RunUntilDone();
+
+                mockTextPanel.VerifySet(b => b.ContentType = ContentType.NONE);
             }
         }
 

--- a/EasyCommands/BlockHandlers/TextSurfaceHandlers.cs
+++ b/EasyCommands/BlockHandlers/TextSurfaceHandlers.cs
@@ -46,6 +46,7 @@ namespace IngameScript {
                     TypeHandler(fontSizeHandler, Return.NUMERIC),
                     TypeHandler(fontColorHandler, Return.COLOR));
 
+                defaultPropertiesByPrimitive[Return.BOOLEAN] = Property.ENABLE;
                 defaultPropertiesByPrimitive[Return.STRING] = Property.TEXT;
                 defaultPropertiesByPrimitive[Return.COLOR] = Property.COLOR;
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.LEVEL;


### PR DESCRIPTION
Looks like this one was missed as part of the Enabled fix previously.  Docs already mention that Enabled is the default property