### PR TITLE
Simplify Block Direction Code

### DIFF
--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/TerminalBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/TerminalBlockTests.cs
@@ -120,7 +120,7 @@ show the ""test terminal""
             using (ScriptTest test = new ScriptTest(script)) {
                 var mockBlock = new Mock<IMyTerminalBlock>();
                 test.MockBlocksOfType("test terminal", mockBlock);
-                MockOrientation(mockBlock, new Vector3(1, 0, 0), new Vector3(0, 1, 0));
+                MockWorldMatrix(mockBlock, Vector3D.Zero, Vector3D.UnitX, Vector3D.UnitY);
 
                 test.RunUntilDone();
 
@@ -135,7 +135,7 @@ show the ""test terminal""
             using (ScriptTest test = new ScriptTest(script)) {
                 var mockBlock = new Mock<IMyTerminalBlock>();
                 test.MockBlocksOfType("test terminal", mockBlock);
-                MockOrientation(mockBlock, new Vector3(1, 0, 0), new Vector3(0, 1, 0));
+                MockWorldMatrix(mockBlock, Vector3D.Zero, Vector3D.UnitX, Vector3D.UnitY);
 
                 test.RunUntilDone();
 
@@ -150,7 +150,7 @@ show the ""test terminal""
             using (ScriptTest test = new ScriptTest(script)) {
                 var mockBlock = new Mock<IMyTerminalBlock>();
                 test.MockBlocksOfType("test terminal", mockBlock);
-                MockOrientation(mockBlock, new Vector3(1, 0, 0), new Vector3(0, 1, 0));
+                MockWorldMatrix(mockBlock, Vector3D.Zero, Vector3D.UnitX, Vector3D.UnitY);
 
                 test.RunUntilDone();
 
@@ -165,7 +165,7 @@ show the ""test terminal""
             using (ScriptTest test = new ScriptTest(script)) {
                 var mockBlock = new Mock<IMyTerminalBlock>();
                 test.MockBlocksOfType("test terminal", mockBlock);
-                MockOrientation(mockBlock, new Vector3(1, 0, 0), new Vector3(0, 1, 0));
+                MockWorldMatrix(mockBlock, Vector3D.Zero, Vector3D.UnitX, Vector3D.UnitY);
 
                 test.RunUntilDone();
 
@@ -180,7 +180,7 @@ show the ""test terminal""
             using (ScriptTest test = new ScriptTest(script)) {
                 var mockBlock = new Mock<IMyTerminalBlock>();
                 test.MockBlocksOfType("test terminal", mockBlock);
-                MockOrientation(mockBlock, new Vector3(1, 0, 0), new Vector3(0, 1, 0));
+                MockWorldMatrix(mockBlock, Vector3D.Zero, Vector3D.UnitX, Vector3D.UnitY);
 
                 test.RunUntilDone();
 
@@ -195,7 +195,7 @@ show the ""test terminal""
             using (ScriptTest test = new ScriptTest(script)) {
                 var mockBlock = new Mock<IMyTerminalBlock>();
                 test.MockBlocksOfType("test terminal", mockBlock);
-                MockOrientation(mockBlock, new Vector3(1, 0, 0), new Vector3(0, 1, 0));
+                MockWorldMatrix(mockBlock, Vector3D.Zero, Vector3D.UnitX, Vector3D.UnitY);
 
                 test.RunUntilDone();
 
@@ -210,7 +210,7 @@ show the ""test terminal""
             using (ScriptTest test = new ScriptTest(script)) {
                 var mockBlock = new Mock<IMyTerminalBlock>();
                 test.MockBlocksOfType("test terminal", mockBlock);
-                MockOrientation(mockBlock, new Vector3(1, 0, 0), new Vector3(0, 1, 0));
+                MockWorldMatrix(mockBlock, Vector3D.Zero, Vector3D.UnitX, Vector3D.UnitY);
 
                 test.RunUntilDone();
 

--- a/EasyCommands.Tests/ScriptTests/MockEntityUtility.cs
+++ b/EasyCommands.Tests/ScriptTests/MockEntityUtility.cs
@@ -69,6 +69,10 @@ namespace EasyCommands.Tests.ScriptTests {
             mockShip.Setup(b => b.WorldMatrix).Returns(MatrixD.Identity);
         }
 
+        public static void MockWorldMatrix<T>(Mock<T> mockBlock, Vector3D position, Vector3D forward, Vector3D up) where T : class, IMyTerminalBlock {
+            mockBlock.Setup(b => b.WorldMatrix).Returns(MatrixD.CreateWorld(position, forward, up));
+        }
+
         public static void MockOrientation<T>(Mock<T> mockBlock, Vector3 forward, Vector3 up) where T : class, IMyTerminalBlock {
             Mock<IMyCubeGrid> mockGrid = new Mock<IMyCubeGrid>();
             mockGrid.Setup(g => g.GridIntegerToWorld(new Vector3I(0, 0, 0))).Returns(new Vector3D(0, 0, 0));

--- a/EasyCommands/BlockHandlers/TerminalBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/TerminalBlockHandlers.cs
@@ -79,12 +79,12 @@ namespace IngameScript {
                 AddPropertyHandler(ValueProperty.ACTION, new SimplePropertyHandler<T>((b, p) => p.attributeValue.GetValue(), (b, p, v) => b.ApplyAction(CastString(p.attributeValue.GetValue())), ResolvePrimitive(0)));
 
                 AddDirectionHandlers(Property.DIRECTION, Direction.FORWARD,
-                    TypeHandler(VectorHandler(b => Normalize(GetBlock2WorldTransform(b).Forward)), Direction.FORWARD),
-                    TypeHandler(VectorHandler(b => Normalize(GetBlock2WorldTransform(b).Backward)), Direction.BACKWARD),
-                    TypeHandler(VectorHandler(b => Normalize(GetBlock2WorldTransform(b).Up)), Direction.UP),
-                    TypeHandler(VectorHandler(b => Normalize(GetBlock2WorldTransform(b).Down)), Direction.DOWN),
-                    TypeHandler(VectorHandler(b => Normalize(GetBlock2WorldTransform(b).Left)), Direction.LEFT),
-                    TypeHandler(VectorHandler(b => Normalize(GetBlock2WorldTransform(b).Right)), Direction.RIGHT));
+                    TypeHandler(VectorHandler(b => b.WorldMatrix.Forward), Direction.FORWARD),
+                    TypeHandler(VectorHandler(b => b.WorldMatrix.Backward), Direction.BACKWARD),
+                    TypeHandler(VectorHandler(b => b.WorldMatrix.Up), Direction.UP),
+                    TypeHandler(VectorHandler(b => b.WorldMatrix.Down), Direction.DOWN),
+                    TypeHandler(VectorHandler(b => b.WorldMatrix.Left), Direction.LEFT),
+                    TypeHandler(VectorHandler(b => b.WorldMatrix.Right), Direction.RIGHT));
 
                 defaultPropertiesByPrimitive[Return.VECTOR] = Property.POSITION;
                 defaultPropertiesByPrimitive[Return.BOOLEAN] = Property.ENABLE;


### PR DESCRIPTION
This PR replaces the current code by reading the directions directly from the blocks WorldMatrix.

The old code is still there.

see #158 