### PR TITLE
Refactor `ParseSeperatorTokens`

### DIFF
--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -464,19 +464,19 @@ namespace IngameScript {
                     : new Token[] { new Token(element, true, characters.Length > 1) })  // Keep the entire item
                 .ToArray();
 
-        String[] ParseSeparateTokens(String command) {
-            var newCommand = command;
-            foreach (var token in separateTokensFirstPass) newCommand = newCommand.Replace(token, " " + token + " ");
-            newCommand = string.Join(" ", newCommand.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries).SelectMany(token => {
+        String[] ParseSeparateTokens(String command) =>
+            AddSpaceArroundTokens(command, separateTokensFirstPass)
+            .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
+            .SelectMany(token => {
                 Primitive ignored;
                 if (separateTokensFirstPass.Contains(token) || ParsePrimitive(token, out ignored)) return new[] { token };
-                foreach (var s in separateTokensSecondPass) token = token.Replace(s, " " + s + " ");
-                return token.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            }));
+                return AddSpaceArroundTokens(token, separateTokensSecondPass).Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            }).ToArray();
 
-            List<char> commandArray = newCommand.ToCharArray().ToList();
-
-            return new string(commandArray.ToArray()).Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+        String AddSpaceArroundTokens(String command, String[] tokens) {
+            var newCommand = command;
+            foreach (var t in tokens) newCommand = newCommand.Replace(t, " " + t + " ");
+            return newCommand;
         }
 
         public static bool ParsePrimitive(String token, out Primitive primitive) {

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -465,15 +465,16 @@ namespace IngameScript {
                 .ToArray();
 
         String[] ParseSeparateTokens(String command) =>
-            AddSpaceArroundTokens(command, separateTokensFirstPass)
+            AddSpaceAroundTokens(command, separateTokensFirstPass)
             .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
             .SelectMany(token => {
                 Primitive ignored;
-                if (separateTokensFirstPass.Contains(token) || ParsePrimitive(token, out ignored)) return new[] { token };
-                return AddSpaceArroundTokens(token, separateTokensSecondPass).Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                return (separateTokensFirstPass.Contains(token) || ParsePrimitive(token, out ignored))
+                    ? new[] { token }
+                    : AddSpaceAroundTokens(token, separateTokensSecondPass).Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
             }).ToArray();
 
-        String AddSpaceArroundTokens(String command, String[] tokens) {
+        String AddSpaceAroundTokens(String command, String[] tokens) {
             var newCommand = command;
             foreach (var t in tokens) newCommand = newCommand.Replace(t, " " + t + " ");
             return newCommand;


### PR DESCRIPTION
While investigating #159 i found some unneeded code.
Instead of first splitting, joining, copying (or rather: constructing a new string from the old ones char array that is cast to a list) and then splitting again, the the first split operation is returned directly. Also the loops to add spaces around the tokens got moved into its own method.

For a few characters more `ParseSurrounded`, `ParseSeperateTokens` and the lambda in `ParseTokens` could return `IEnumerator<...>` and the `toArray` calls could be removed.
This would make these functions truely lazy and maybe give a small performance boost on the tokenizing step.