### PR TITLE
Rework tokenizing

### DIFF
--- a/EasyCommands.Tests/EasyCommands.Tests.csproj
+++ b/EasyCommands.Tests/EasyCommands.Tests.csproj
@@ -229,11 +229,12 @@
     <Compile Include="ScriptTests\FunctionalTests\BlockHandlers\DecoyBlockTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\BlockHandlers\AntennaBlockTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\BlockHandlers\WarheadBlockTests.cs" />
-    <Compile Include="TokenParsingTests\BracketParsingTests.cs" />
-    <Compile Include="TokenParsingTests\StringParsingTests.cs" />
-    <Compile Include="TokenParsingTests\ParenthesisParsingTests.cs" />
-    <Compile Include="TokenParsingTests\ItemParsingTests.cs" />
-    <Compile Include="TokenParsingTests\BlueprintParsingTests.cs" />
+    <Compile Include="TokenizeTests\BracketTests.cs" />
+    <Compile Include="TokenizeTests\StringTests.cs" />
+    <Compile Include="TokenizeTests\ParenthesisTests.cs" />
+    <Compile Include="TokenizeTests\ItemParsingTests.cs" />
+    <Compile Include="TokenizeTests\BlueprintParsingTests.cs" />
+    <Compile Include="TokenizeTests\FloatingPointTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Instructions.readme" />

--- a/EasyCommands.Tests/TokenizeTests/BlueprintParsingTests.cs
+++ b/EasyCommands.Tests/TokenizeTests/BlueprintParsingTests.cs
@@ -5,7 +5,7 @@ using Malware.MDKUtilities;
 using IngameScript;
 using static EasyCommands.Tests.ScriptTests.MockEntityUtility;
 
-namespace EasyCommands.Tests.TokenParsingTests {
+namespace EasyCommands.Tests.TokenizeTests {
     [TestClass]
     public class BlueprintParsingTests : ForceLocale {
         Program program = MDKFactory.CreateProgram<Program>();        

--- a/EasyCommands.Tests/TokenizeTests/BracketTests.cs
+++ b/EasyCommands.Tests/TokenizeTests/BracketTests.cs
@@ -4,13 +4,13 @@ using Malware.MDKUtilities;
 using IngameScript;
 using static IngameScript.Program;
 
-namespace EasyCommands.Tests.TokenParsingTests {
+namespace EasyCommands.Tests.TokenizeTests {
     [TestClass]
-    public class BracketParsingTests : ForceLocale {        
+    public class BracketTests : ForceLocale {
         [TestMethod]
         public void TestBasicBrackets() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("test [ string ]");
+            var tokens = program.Tokenize("test [ string ]");
             Assert.AreEqual(4, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
             Assert.AreEqual("[", tokens[1].original);
@@ -21,7 +21,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void TestBracketsMissingSpaces() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("test [string] there");
+            var tokens = program.Tokenize("test [string] there");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
             Assert.AreEqual("[", tokens[1].original);
@@ -33,7 +33,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void TestInlineBrackets() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("test list[string] there");
+            var tokens = program.Tokenize("test list[string] there");
             Assert.AreEqual(6, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
             Assert.AreEqual("list", tokens[1].original);
@@ -46,7 +46,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void TestMultiInlineBrackets() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("test list[string1][string2] there");
+            var tokens = program.Tokenize("test list[string1][string2] there");
             Assert.AreEqual(9, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
             Assert.AreEqual("list", tokens[1].original);
@@ -62,7 +62,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void TestCommaSeparatedInlineBrackets() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("test list[string1,string2] there");
+            var tokens = program.Tokenize("test list[string1,string2] there");
             Assert.AreEqual(8, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
             Assert.AreEqual("list", tokens[1].original);
@@ -77,7 +77,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void TestMissingSpaceEmptyBrackets() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("test list[] there");
+            var tokens = program.Tokenize("test list[] there");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
             Assert.AreEqual("list", tokens[1].original);
@@ -89,7 +89,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void TestMissingSpaceBeforeOpeningBracket() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("test [string ]there");
+            var tokens = program.Tokenize("test [string ]there");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
             Assert.AreEqual("[", tokens[1].original);
@@ -101,7 +101,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void TestMissingSpaceAfterClosingBracket() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("test[ string ] there");
+            var tokens = program.Tokenize("test[ string ] there");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
             Assert.AreEqual("[", tokens[1].original);
@@ -113,7 +113,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void TestEmbeddedBracketsMissingSpaces() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("test [[string] there]");
+            var tokens = program.Tokenize("test [[string] there]");
             Assert.AreEqual(7, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
             Assert.AreEqual("[", tokens[1].original);

--- a/EasyCommands.Tests/TokenizeTests/FloatingPointTests.cs
+++ b/EasyCommands.Tests/TokenizeTests/FloatingPointTests.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using Malware.MDKUtilities;
+using IngameScript;
+
+namespace EasyCommands.Tests.TokenizeTests {
+    [TestClass]
+    public class FloatingPointTests : ForceLocale {
+        [TestMethod]
+        public void SeparateTokensMissingSpaces() {
+            VerifyTokensSplit(",");
+            VerifyTokensSplit("+");
+            VerifyTokensSplit("*");
+            VerifyTokensSplit("/");
+            VerifyTokensSplit("!");
+            VerifyTokensSplit("^");
+            VerifyTokensSplit("..");
+            //VerifyTokensSplit("."); that one would cause havok
+            VerifyTokensSplit(":"); //might as well test this one now
+            VerifyTokensSplit("%");
+            VerifyTokensSplit(">");
+            VerifyTokensSplit(">=");
+            VerifyTokensSplit("<");
+            VerifyTokensSplit("<=");
+            VerifyTokensSplit("==");
+            VerifyTokensSplit("=");
+            VerifyTokensSplit("&&");
+            VerifyTokensSplit("&");
+            VerifyTokensSplit("||");
+            VerifyTokensSplit("|");
+            VerifyTokensSplit("@");
+        }
+
+        void VerifyTokensSplit(string token) {
+            var program = MDKFactory.CreateProgram<Program>();
+            var tokens = program.Tokenize("assign a to 2.0" + token + ".5");
+            Assert.AreEqual(6, tokens.Count);
+            Assert.AreEqual("assign", tokens[0].original);
+            Assert.AreEqual("a", tokens[1].original);
+            Assert.AreEqual("to", tokens[2].original);
+            Assert.AreEqual("2.0", tokens[3].original);
+            Assert.AreEqual(token, tokens[4].original);
+            Assert.AreEqual(".5", tokens[5].original);
+        }
+    }
+}

--- a/EasyCommands.Tests/TokenizeTests/ItemParsingTests.cs
+++ b/EasyCommands.Tests/TokenizeTests/ItemParsingTests.cs
@@ -5,7 +5,7 @@ using Malware.MDKUtilities;
 using IngameScript;
 using static EasyCommands.Tests.ScriptTests.MockEntityUtility;
 
-namespace EasyCommands.Tests.TokenParsingTests {
+namespace EasyCommands.Tests.TokenizeTests {
     [TestClass]
     public class ItemParsingTests : ForceLocale {
         Program program = MDKFactory.CreateProgram<Program>();        

--- a/EasyCommands.Tests/TokenizeTests/ParenthesisTests.cs
+++ b/EasyCommands.Tests/TokenizeTests/ParenthesisTests.cs
@@ -4,13 +4,13 @@ using Malware.MDKUtilities;
 using IngameScript;
 using static IngameScript.Program;
 
-namespace EasyCommands.Tests.TokenParsingTests {
+namespace EasyCommands.Tests.TokenizeTests {
     [TestClass]
-    public class ParenthesisParsingTests : ForceLocale {
+    public class ParenthesisTests : ForceLocale {
         [TestMethod]
         public void TestBasicParenthesis() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("test ( string )");
+            var tokens = program.Tokenize("test ( string )");
             Assert.AreEqual(4, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
             Assert.AreEqual("(", tokens[1].original);
@@ -21,7 +21,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void TestParenthesesMissingSpaces() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("test (string) there");
+            var tokens = program.Tokenize("test (string) there");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
             Assert.AreEqual("(", tokens[1].original);
@@ -33,7 +33,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void TestMissingSpaceBeforeOpeningParenthesis() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("test (string )there");
+            var tokens = program.Tokenize("test (string )there");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
             Assert.AreEqual("(", tokens[1].original);
@@ -45,7 +45,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void TestMissingSpaceAfterClosingParenthesis() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("test( string ) there");
+            var tokens = program.Tokenize("test( string ) there");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
             Assert.AreEqual("(", tokens[1].original);
@@ -57,7 +57,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void TestEmbeddedParenthesesMissingSpaces() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("test ((string) there)");
+            var tokens = program.Tokenize("test ((string) there)");
             Assert.AreEqual(7, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
             Assert.AreEqual("(", tokens[1].original);

--- a/EasyCommands.Tests/TokenizeTests/StringTests.cs
+++ b/EasyCommands.Tests/TokenizeTests/StringTests.cs
@@ -4,13 +4,13 @@ using Malware.MDKUtilities;
 using IngameScript;
 using static IngameScript.Program;
 
-namespace EasyCommands.Tests.TokenParsingTests {
+namespace EasyCommands.Tests.TokenizeTests {
     [TestClass]
-    public class StringParsingTests : ForceLocale {
+    public class StringTests : ForceLocale {
         [TestMethod]
         public void BasicStrings() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("turn on the rotors");
+            var tokens = program.Tokenize("turn on the rotors");
             Assert.AreEqual(4, tokens.Count);
             Assert.AreEqual("turn", tokens[0].original);
             Assert.AreEqual("on", tokens[1].original);
@@ -21,7 +21,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void StringWithDoubleQuotes() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("turn on the \"test rotors\"");
+            var tokens = program.Tokenize("turn on the \"test rotors\"");
             Assert.AreEqual(4, tokens.Count);
             Assert.AreEqual("turn", tokens[0].original);
             Assert.AreEqual("on", tokens[1].original);
@@ -32,7 +32,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void MultipleDoubleQuotes() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("tell the \"test program\" to \"run gotoTest\"");
+            var tokens = program.Tokenize("tell the \"test program\" to \"run gotoTest\"");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("tell", tokens[0].original);
             Assert.AreEqual("the", tokens[1].original);
@@ -44,7 +44,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void SingleQuotes() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("tell the program to 'run gotoTest'");
+            var tokens = program.Tokenize("tell the program to 'run gotoTest'");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("tell", tokens[0].original);
             Assert.AreEqual("the", tokens[1].original);
@@ -56,7 +56,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void MultipleSingleQuotes() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("tell the 'test program' to 'run gotoTest'");
+            var tokens = program.Tokenize("tell the 'test program' to 'run gotoTest'");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("tell", tokens[0].original);
             Assert.AreEqual("the", tokens[1].original);
@@ -68,7 +68,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void SingleQuotesAndDoubleQuotes() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("tell the \"test program\" to 'run gotoTest'");
+            var tokens = program.Tokenize("tell the \"test program\" to 'run gotoTest'");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("tell", tokens[0].original);
             Assert.AreEqual("the", tokens[1].original);
@@ -80,7 +80,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void EscapedSingleQuotes() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("print `It's awesome!`");
+            var tokens = program.Tokenize("print `It's awesome!`");
             Assert.AreEqual(2, tokens.Count);
             Assert.AreEqual("print", tokens[0].original);
             Assert.AreEqual("It's awesome!", tokens[1].original);
@@ -89,7 +89,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void DoubleQuotesInsideSingleQuotes() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("tell the \"test program\" to 'run \"goto testFunction\"'");
+            var tokens = program.Tokenize("tell the \"test program\" to 'run \"goto testFunction\"'");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("tell", tokens[0].original);
             Assert.AreEqual("the", tokens[1].original);
@@ -125,7 +125,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void SubtractionMissingSpaces() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("assign a to b-c");
+            var tokens = program.Tokenize("assign a to b-c");
             Assert.AreEqual(6, tokens.Count);
             Assert.AreEqual("assign", tokens[0].original);
             Assert.AreEqual("a", tokens[1].original);
@@ -138,7 +138,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void NegativeNumbersAreLeftAlone() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("assign a to -3");
+            var tokens = program.Tokenize("assign a to -3");
             Assert.AreEqual(4, tokens.Count);
             Assert.AreEqual("assign", tokens[0].original);
             Assert.AreEqual("a", tokens[1].original);
@@ -149,7 +149,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
         [TestMethod]
         public void VectorsAreLeftAlone() {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("assign a to -345.34:-3452.34:-35343.345");
+            var tokens = program.Tokenize("assign a to -345.34:-3452.34:-35343.345");
             Assert.AreEqual(4, tokens.Count);
             Assert.AreEqual("assign", tokens[0].original);
             Assert.AreEqual("a", tokens[1].original);
@@ -159,7 +159,7 @@ namespace EasyCommands.Tests.TokenParsingTests {
 
         void VerifyTokensSplit(string token) {
             var program = MDKFactory.CreateProgram<Program>();
-            var tokens = program.ParseTokens("assign a to b" + token + "c");
+            var tokens = program.Tokenize("assign a to b" + token + "c");
             Assert.AreEqual(6, tokens.Count);
             Assert.AreEqual("assign", tokens[0].original);
             Assert.AreEqual("a", tokens[1].original);

--- a/EasyCommands/CommandParsers/ParsingEngine.cs
+++ b/EasyCommands/CommandParsers/ParsingEngine.cs
@@ -47,7 +47,7 @@ namespace IngameScript {
 
                 foreach (int i in functionIndices) {
                     String functionString = commandStrings[i].Remove(0, 1).Trim();
-                    List<Token> nameAndParams = ParseTokens(functionString);
+                    List<Token> nameAndParams = Tokenize(functionString);
                     String functionName = nameAndParams[0].original;
                     nameAndParams.RemoveAt(0);
                     FunctionDefinition definition = new FunctionDefinition(functionName, nameAndParams.Select(t => t.original).ToList());
@@ -57,7 +57,7 @@ namespace IngameScript {
                 foreach (int i in functionIndices) {
                     int startingLineNumber = i + 1 + implicitMainOffset;
                     String functionString = commandStrings[i].Remove(0, 1).Trim();
-                    List<Token> nameAndParams = ParseTokens(functionString);
+                    List<Token> nameAndParams = Tokenize(functionString);
                     String functionName = nameAndParams[0].original;
 
                     parsingTasks.Add(new ParseCommandLineTask(commandStrings.GetRange(i + 1, commandStrings.Count - (i + 1)).ToList(), startingLineNumber, commandLines => {
@@ -164,7 +164,7 @@ namespace IngameScript {
         }
 
         public Command ParseCommand(String commandLine, int lineNumber = 0) =>
-            ParseCommand(ParseCommandParameters(ParseTokens(commandLine)), lineNumber);
+            ParseCommand(ParseCommandParameters(Tokenize(commandLine)), lineNumber);
 
         Command ParseCommand(List<CommandParameter> parameters, int lineNumber) {
             CommandReferenceParameter command = ParseParameters<CommandReferenceParameter>(parameters);
@@ -179,7 +179,7 @@ namespace IngameScript {
 
             public CommandLine(String command, int line) {
                 depth = command.TakeWhile(Char.IsWhiteSpace).Count();
-                commandParameters = PROGRAM.ParseCommandParameters(PROGRAM.ParseTokens(command));
+                commandParameters = PROGRAM.ParseCommandParameters(PROGRAM.Tokenize(command));
                 lineNumber = line;
             }
         }

--- a/EasyCommands/Commands/Selectors.cs
+++ b/EasyCommands/Commands/Selectors.cs
@@ -100,7 +100,7 @@ namespace IngameScript {
             }
 
             Block ResolveType(String selector, out bool isGroup) {
-                var tokens = PROGRAM.ParseTokens(selector);
+                var tokens = PROGRAM.Tokenize(selector);
                 var parameters = PROGRAM.ParseCommandParameters(tokens);
                 var blockType = findLast<BlockTypeCommandParameter>(parameters);
                 isGroup = findLast<GroupCommandParameter>(parameters) != null;


### PR DESCRIPTION
This PR implements the changes discussed in #170 and renames the tests accordingly.

Switching from `String[]` to  `IEnumerable<String>` removes quite a number of allocations and does speed up the unit testing by about a third on my system.

_I dont like the implementation very much but C# especially v6 is limiting._