### PR TITLE
Added ColonCommandParameter

### DIFF
--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/TernaryOperatorTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/TernaryOperatorTests.cs
@@ -19,5 +19,19 @@ namespace EasyCommands.Tests.ScriptTests {
                 Assert.AreEqual("Fail", test.Logger[1], lines[1]);
             }
         }
+
+        [TestMethod]
+        public void ExplicitTernaryOperator() {
+            var lines = new List<String> {
+                @"True ? ""Success"" :: ""Fail""",
+                @"False ? ""Success"" :: ""Fail""" };
+
+            using (var test = new SimpleExpressionsTest(lines)) {
+                test.RunOnce();
+
+                Assert.AreEqual("Success", test.Logger[0], lines[0]);
+                Assert.AreEqual("Fail", test.Logger[1], lines[1]);
+            }
+        }
     }
 }

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -22,7 +22,7 @@ namespace IngameScript {
         //Internal (Don't touch!)
         Dictionary<String, List<CommandParameter>> propertyWords = NewDictionary<string, List<CommandParameter>>();
 
-        string[] firstPassTokens = new[] { "(", ")", "[", "]", ",", "*", "/", "!", "^", "..", "%", ">=", "<=", "==", "&&", "||", "@", "$", "->", "++", "+=", "--", "-=" };
+        string[] firstPassTokens = new[] { "(", ")", "[", "]", ",", "*", "/", "!", "^", "..", "%", ">=", "<=", "==", "&&", "||", "@", "$", "->", "++", "+=", "--", "-=", "::"};
         string[] secondPassTokens = new[] { "<", ">", "=", "&", "|", "-", "+", "?", ":" };
         string[] thirdPassTokens = new[] { "." };
 
@@ -162,7 +162,8 @@ namespace IngameScript {
             AddWords(Words("take"), new TransferCommandParameter(false));
             AddWords(Words("->"), new KeyedVariableCommandParameter());
             AddWords(Words("?"), new TernaryConditionIndicatorParameter());
-            AddWords(Words(":"), new TernaryConditionSeparatorParameter());
+            AddWords(Words(":"), new ColonCommandParameter());
+            AddWords(Words("::"), new TernaryConditionSeparatorParameter());
             AddWords(Words("each", "every"), new IteratorCommandParameter());
 
             //Conditional Words
@@ -347,6 +348,7 @@ namespace IngameScript {
             RegisterToString<ThatCommandParameter>(p => "That");
             RegisterToString<AssignmentCommandParameter>(p => "[Action]");
             RegisterToString<PropertyCommandParameter>(p => "Property[id=" + p.value.propertyType + "]");
+            RegisterToString<TernaryConditionSeparatorParameter>(p => ":");
         }
 
         Dictionary<Type, Func<CommandParameter, object>> commandParameterStrings = NewDictionary<Type, Func<CommandParameter, object>>();
@@ -460,7 +462,7 @@ namespace IngameScript {
             ? NewList<Token>()
             : TokenizeEnclosed(commandString, "`\'\"",
                 u => u.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
-                    .SelectMany(v => firstPass(v))
+                    .SelectMany(v => firstPass(v.Replace(" : ", " :: ")))
                     .Select(v => new Token(v, false, false))
                     .ToArray())
             .ToList();

--- a/EasyCommands/CommandParsers/ProcessingEngine.cs
+++ b/EasyCommands/CommandParsers/ProcessingEngine.cs
@@ -237,6 +237,9 @@ namespace IngameScript {
             FourValueRule(Type<TransferCommandParameter>, requiredRight<SelectorCommandParameter>(), requiredRight<SelectorCommandParameter>(), requiredRight<VariableCommandParameter>(), optionalRight<VariableCommandParameter>(),
                 (t, s1, s2, v1, v2) => new CommandReferenceParameter(new TransferItemCommand(s1.value, s2.value, v1.value, v2.HasValue() ? v2.GetValue().value : null))),
 
+            //Convert Ambiguous Colon to Ternary Condition Separator
+            NoValueRule(Type<ColonCommandParameter>, b => new TernaryConditionSeparatorParameter()),
+
             //TernaryConditionProcessor
             FourValueRule(Type<TernaryConditionIndicatorParameter>, requiredLeft<VariableCommandParameter>(), requiredRight<VariableCommandParameter>(), requiredRight<TernaryConditionSeparatorParameter>(), requiredRight<VariableCommandParameter>(),
                 (i, conditionValue, positiveValue, seperator, negativeValue) => new VariableCommandParameter(new TernaryConditionVariable() {

--- a/EasyCommands/Commands/CommandParameters.cs
+++ b/EasyCommands/Commands/CommandParameters.cs
@@ -52,6 +52,7 @@ namespace IngameScript {
         public class KeyedVariableCommandParameter : SimpleCommandParameter { }
         public class TernaryConditionIndicatorParameter : SimpleCommandParameter { }
         public class TernaryConditionSeparatorParameter : SimpleCommandParameter { }
+        public class ColonCommandParameter : SimpleCommandParameter { }
         public class MinusCommandParameter : SimpleCommandParameter { }
 
         public abstract class ValueCommandParameter<T> : CommandParameter {


### PR DESCRIPTION
POC for adding a new colon command parameter.

Doesn't have tests, but shows we can use this to distinguish "a:b:c : d:e:f"

This can be done, in combination with the vector variable parsing, to enable intended behavior that works with ternary conditions, I believe, using spacing to indicate the intended behavior.

