### PR TITLE
Fixed issue with broadcast listeners remaining active after re-parsin…

### DIFF
--- a/EasyCommands.Tests/EasyCommands.Tests.csproj
+++ b/EasyCommands.Tests/EasyCommands.Tests.csproj
@@ -179,6 +179,7 @@
     <Compile Include="ScriptTests\FunctionalTests\Operations\TernaryOperatorTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Commands\SimpleWaitCommandTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Operations\Comparisons\SimpleComparisonsColorTests.cs" />
+    <Compile Include="ScriptTests\FunctionalTests\MessageHandlingTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Variables\SimpleAggregationTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Primitives\SimpleColorTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Primitives\SimpleVectorTests.cs" />

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/MessageHandlingTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/MessageHandlingTests.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using IngameScript;
+
+namespace EasyCommands.Tests.ScriptTests {
+    [TestClass]
+    public class MessageHandlingTests {
+        [TestMethod]
+        public void NewlyParsedScriptIgnoresMessages() {
+            using (var test = new ScriptTest(@"print 'Hello World'")) {
+                test.mockIGC.RegisterBroadcastListener("channel");
+                test.MockMessages("channel", @"print 'Incoming Message'");
+
+                test.RunOnce();
+
+                Assert.AreEqual("Hello World", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void PendingMessagesAreProcessedFirst() {
+            var script = @"
+print 'Hello World'
+wait
+print 'Hello World 2'
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.AreEqual("Hello World", test.Logger[0]);
+                test.Logger.Clear();
+
+                test.mockIGC.RegisterBroadcastListener("channel");
+                test.MockMessages("channel", @"print 'Incoming Message'");
+
+                test.RunOnce();
+
+                Assert.AreEqual("Incoming Message", test.Logger[0]);
+                test.Logger.Clear();
+
+                test.RunOnce();
+
+                Assert.AreEqual("Hello World 2", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void UpdatedScriptDisablesAllBroadcastListenersAndClearsPendingMessages() {
+            using (var test = new ScriptTest(@"print 'Hello World'")) {
+                test.RunOnce();
+
+                Assert.AreEqual("Hello World", test.Logger[0]);
+                test.Logger.Clear();
+
+                test.mockIGC.RegisterBroadcastListener("channel");
+                test.MockMessages("channel", @"print 'Incoming Message'");
+
+                test.RunOnce();
+
+                Assert.AreEqual("Incoming Message", test.Logger[0]);
+                test.Logger.Clear();
+
+                test.setScript(@"print 'Hello World 2'");
+                test.MockMessages("channel", "print message1", "print message2");
+
+                test.RunOnce();
+
+                Assert.AreEqual("Hello World 2", test.Logger[0]);
+                test.mockIGC.mockListeners.TrueForAll(listener => !listener.IsActive && listener.messages.Count == 0);
+            }
+        }
+    }
+}


### PR DESCRIPTION
…g script

Previously broadcast listeners would incorrectly remain active even after re-parsing the script.

This commit also removes an unnecessary delegate from the script whose purpose was only to give us a hook for setting messages.  This has been replaced with a
complete Mock IGC instance.

This PR fixes #167 