### PR TITLE
Added Forget Command Support

### DIFF
--- a/EasyCommands.Tests/EasyCommands.Tests.csproj
+++ b/EasyCommands.Tests/EasyCommands.Tests.csproj
@@ -174,6 +174,7 @@
     <Compile Include="ScriptTests\FunctionalTests\BlockHandlers\JumpDriveBlockTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Commands\ControlCommandTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Commands\IterationCommandTests.cs" />
+    <Compile Include="ScriptTests\FunctionalTests\Commands\ListenCommandTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Operations\SimpleRandomTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Operations\SimpleShuffleTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Operations\TernaryOperatorTests.cs" />

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Commands/ListenCommandTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Commands/ListenCommandTests.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Collections.Generic;
+using IngameScript;
+using Malware.MDKUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Sandbox.ModAPI.Ingame;
+using SpaceEngineers.Game.ModAPI;
+using VRageMath;
+
+namespace EasyCommands.Tests.ScriptTests {
+    [TestClass]
+    public class ListenCommandTests {
+
+        [TestMethod]
+        public void ListenChannel() {
+            using (var test = new ScriptTest(@"listen myChannel")) {
+                test.RunUntilDone();
+
+                var registeredChannel = test.mockIGC.GetMockBroadcastListener("myChannel");
+                Assert.IsNotNull(registeredChannel);
+                Assert.IsTrue(registeredChannel.IsActive);
+            }
+        }
+
+        [TestMethod]
+        public void ListenOnAlreadyRegisteredChannelDoesNothing() {
+            using (var test = new ScriptTest(@"listen myChannel")) {
+
+                test.RunUntilDone();
+
+                var registeredChannel = test.mockIGC.GetMockBroadcastListener("myChannel");
+                Assert.IsNotNull(registeredChannel);
+                Assert.IsTrue(registeredChannel.IsActive);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual(1, test.mockIGC.mockListeners.Count);
+                registeredChannel = test.mockIGC.GetMockBroadcastListener("myChannel");
+                Assert.IsNotNull(registeredChannel);
+                Assert.IsTrue(registeredChannel.IsActive);
+            }
+        }
+
+        [TestMethod]
+        public void ListenOnIgnoredChannelReregisters() {
+            using (var test = new ScriptTest(@"
+listen myChannel
+wait
+forget myChannel
+wait
+listen myChannel
+")) {
+                test.RunOnce();
+
+                var registeredChannel = test.mockIGC.GetMockBroadcastListener("myChannel");
+                Assert.IsNotNull(registeredChannel);
+                Assert.IsTrue(registeredChannel.IsActive);
+
+                test.RunOnce();
+
+                Assert.AreEqual(1, test.mockIGC.mockListeners.Count);
+                registeredChannel = test.mockIGC.GetMockBroadcastListener("myChannel");
+                Assert.IsNotNull(registeredChannel);
+                Assert.IsFalse(registeredChannel.IsActive);
+
+                test.RunOnce();
+
+                Assert.AreEqual(1, test.mockIGC.mockListeners.Count);
+                registeredChannel = test.mockIGC.GetMockBroadcastListener("myChannel");
+                Assert.IsNotNull(registeredChannel);
+                Assert.IsTrue(registeredChannel.IsActive);
+            }
+        }
+
+        [TestMethod]
+        public void IgnoreChannel() {
+            using (var test = new ScriptTest(@"
+listen myChannel
+wait
+forget myChannel
+")) {
+                test.RunOnce();
+
+                var registeredChannel = test.mockIGC.GetMockBroadcastListener("myChannel");
+                Assert.IsNotNull(registeredChannel);
+                Assert.IsTrue(registeredChannel.IsActive);
+
+                test.RunOnce();
+
+                Assert.AreEqual(1, test.mockIGC.mockListeners.Count);
+                registeredChannel = test.mockIGC.GetMockBroadcastListener("myChannel");
+                Assert.IsNotNull(registeredChannel);
+                Assert.IsFalse(registeredChannel.IsActive);
+            }
+        }
+
+        [TestMethod]
+        public void IgnoreUnregisteredChannelDoesNothing() {
+            using (var test = new ScriptTest(@"ignore myChannel")) {
+                test.RunUntilDone();
+
+                Assert.AreEqual(0, test.mockIGC.mockListeners.Count);
+            }
+        }
+    }
+}

--- a/EasyCommands.Tests/ScriptTests/ScriptTest.cs
+++ b/EasyCommands.Tests/ScriptTests/ScriptTest.cs
@@ -399,7 +399,7 @@ namespace EasyCommands.Tests.ScriptTests
                 mockListeners.Add(mockListener);
                 broadcastListener = mockListener;
             }
-
+            broadcastListener.IsActive = true;
             return broadcastListener;
         }
 

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -153,7 +153,8 @@ namespace IngameScript {
             AddWords(Words("wait", "hold"), new WaitCommandParameter());
             AddWords(Words("call", "gosub"), new FunctionCommandParameter(false));
             AddWords(Words("goto"), new FunctionCommandParameter(true));
-            AddWords(Words("listen", "channel"), new ListenCommandParameter());
+            AddWords(Words("listen", "channel", "register", "subscribe"), new ListenCommandParameter(true));
+            AddWords(Words("forget", "dismiss", "ignore", "deregister", "unsubscribe"), new ListenCommandParameter(false));
             AddWords(Words("send"), new SendCommandParameter());
             AddWords(Words("print", "log", "echo", "write"), new PrintCommandParameter());
             AddWords(Words("queue", "schedule"), new QueueCommandParameter(false));

--- a/EasyCommands/CommandParsers/ProcessingEngine.cs
+++ b/EasyCommands/CommandParsers/ProcessingEngine.cs
@@ -314,7 +314,7 @@ namespace IngameScript {
 
             //ListenCommandProcessor
             OneValueRule(Type<ListenCommandParameter>, requiredRight<VariableCommandParameter>(),
-                (p, var) => new CommandReferenceParameter(new ListenCommand(var.value))),
+                (p, var) => new CommandReferenceParameter(new ListenCommand(var.value, p.value))),
 
             //IterationProcessor
             OneValueRule(Type<RepetitionCommandParameter>, requiredEither<CommandReferenceParameter>(),

--- a/EasyCommands/Commands/CommandParameters.cs
+++ b/EasyCommands/Commands/CommandParameters.cs
@@ -42,7 +42,6 @@ namespace IngameScript {
         public class ReverseCommandParameter : SimpleCommandParameter { }
         public class WaitCommandParameter : SimpleCommandParameter { }
         public class SendCommandParameter : SimpleCommandParameter { }
-        public class ListenCommandParameter : SimpleCommandParameter { }
         public class ElseCommandParameter : SimpleCommandParameter { }
         public class PrintCommandParameter : SimpleCommandParameter { }
         public class SelfCommandParameter : SimpleCommandParameter { }
@@ -65,6 +64,10 @@ namespace IngameScript {
                 }
                 set { }
             }
+        }
+
+        public class ListenCommandParameter : ValueCommandParameter<bool> {
+            public ListenCommandParameter(bool v) : base(v) { }
         }
 
         public class QueueCommandParameter : ValueCommandParameter<bool> {

--- a/EasyCommands/Commands/Commands.cs
+++ b/EasyCommands/Commands/Commands.cs
@@ -218,13 +218,20 @@ namespace IngameScript {
 
         public class ListenCommand : Command {
             public Variable tag;
+            bool shouldListen;
 
-            public ListenCommand(Variable v) {
+            public ListenCommand(Variable v, bool listen) {
                 tag = v;
+                shouldListen = listen;
             }
 
             public override bool Execute() {
-                PROGRAM.IGC.RegisterBroadcastListener(CastString(tag.GetValue()));
+                var broadcastTag = CastString(tag.GetValue());
+                if (shouldListen) {
+                    PROGRAM.IGC.RegisterBroadcastListener(broadcastTag);
+                } else {
+                    PROGRAM.BroadCastListenerAction(listener => listener.Tag == broadcastTag, listener => PROGRAM.IGC.DisableBroadcastListener(listener));
+                }
                 return true;
             }
         }

--- a/docs/EasyCommands/cheatsheet.md
+++ b/docs/EasyCommands/cheatsheet.md
@@ -137,8 +137,9 @@ These properties require a Variable value as part of the property
 * Tick - ```tick, ticks``` - wait for ticks instead of seconds
 * Call Function - ```call, gosub```
 * Goto Function - ```goto```
-* Listen - ```listen, channel```
 * Send - ```send```
+* Listen - ```listen, channel, register, subscribe```
+* Forget - ```forget, dismiss, ignore, deregister, unsubscribe```
 * Print - ```print, log, echo, write```
 * Queue - ```queue, schedule```
 * Async - ```async, parallel```

--- a/docs/EasyCommands/commands.md
+++ b/docs/EasyCommands/commands.md
@@ -694,9 +694,9 @@ repeat
 
 If you specify a "goto <function>" somewhere before calling "repeat", the script will repeat from the last "goto function".  Note that any previous parameters passed to that function are not passed when calling repeat.
 
-## Send/Listen Commands
+## Send/Listen/Forget Commands
 
-Sometimes you might want to send or listen for events from other grids.  You can do this from EasyCommands using the ```send``` and ```listen``` commands.
+Sometimes you might want to send or listen for events from other grids.  You can do this from EasyCommands using the ```send``` and ```listen``` commands.  If later you want to stop listening for those events, you can do so with the ```forget``` command.
 
 ### Send Command
 
@@ -711,9 +711,10 @@ send 'open the "Outer Doors"' to myBaseChannel
 ```
 
 ### Listen Command
+To listen for commmands from your script, you can use the listen command.  The outline of this command is
+```listen <channel>```.
 
-To listen for commmands from your script, you can use the ```listen``` command.  The outline of this command is
-```listen <channel>```
+Keywords: ```listen, channel, register, subscribe```
 
 Note that your script needs to be running in order to be triggered by an event from a channel.  So it's important to put the script in an "always listening" mode, which can be accomplished in several ways but the easiest would be as follows:
 
@@ -722,7 +723,23 @@ listen "myChannel"
 wait until false
 ```
 
-### Using these commands together
+### Forget Command
+To stop listening to a channel and ignore future messages from that channel, you can use the ignore command.  The outline of this command is
+```forget <channel>```.
+
+Keywords: ```forget, dismiss, ignore, deregister, unsubscribe```
+
+```
+#start listening
+listen myChannel
+
+#Do some stuff
+
+#stop listening
+forget myChannel
+```
+
+### Using Send/Listen commands together
 You can quickly do some fun cross-grid things with these two commands.  Here's a simple example that enables keyless entry to your garage from your rover:
 
 Base Script:


### PR DESCRIPTION
This commit adds the ability to forget a previously listened to channel and adds additional words for listening and forgetting channels.

This commit also adds some previously missing tests for the ListenCommand.

Resolves #168 