### PR TITLE
Fixed issue where combining lists used references instead of values

### DIFF
--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Primitives/SimpleListTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Primitives/SimpleListTests.cs
@@ -593,6 +593,42 @@ Print ""After: "" + myList
         }
 
         [TestMethod]
+        public void appendVariableToListAddsValueNotReference() {
+            String script = @"
+set myString to ""someString""
+set myMap to[]
+
+myMap+=[myString]
+set myString to ""someOtherString""
+
+print myMap
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunUntilDone();
+
+                Assert.AreEqual("[someString]", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void appendKeyedVariableToListAddsValueNotReference() {
+            String script = @"
+set myString to ""someString""
+set myMap to[]
+
+myMap+=[myString -> 0]
+set myString to ""someOtherString""
+
+print myMap
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunUntilDone();
+
+                Assert.AreEqual("[someString->0]", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
         public void AddTwoLists() {
             String script = @"
 :main

--- a/EasyCommands/Common/Collections.cs
+++ b/EasyCommands/Common/Collections.cs
@@ -62,7 +62,7 @@ namespace IngameScript {
             public KeyedList Combine(KeyedList other) {
                 var otherKeys = new HashSet<string>(other.keyedValues.Where(k => k.HasKey()).Select(k => k.GetKey()).Distinct());
                 var uniqueKeyedVariables = keyedValues.Where(k => !k.HasKey() || !otherKeys.Contains(k.GetKey()));
-                return NewKeyedList(uniqueKeyedVariables.Concat(other.GetValues()));
+                return NewKeyedList(uniqueKeyedVariables.Concat(other.keyedValues.Select(k => k.DeepCopy())));
             }
 
             public KeyedList Remove(KeyedList other) {
@@ -74,7 +74,7 @@ namespace IngameScript {
             public KeyedList Keys() => NewKeyedList(keyedValues.Where(v => v.HasKey()).Select(v => GetStaticVariable(v.GetKey())));
             public KeyedList Values() => NewKeyedList(keyedValues.Select(v => v.Value));
 
-            public KeyedList DeepCopy() => NewKeyedList(keyedValues.Select(k => new KeyedVariable(k.Key, new StaticVariable(k.Value.GetValue().DeepCopy()))));
+            public KeyedList DeepCopy() => NewKeyedList(keyedValues.Select(k => k.DeepCopy()));
 
             public String Print() => "[" + string.Join(",", keyedValues.Select(k => k.Print())) + "]";
         }

--- a/EasyCommands/Common/Variables.cs
+++ b/EasyCommands/Common/Variables.cs
@@ -270,6 +270,8 @@ namespace IngameScript {
 
             public String Print() => (HasKey() ? Wrap(GetKey()) + "->" : "") + Wrap(CastString(GetValue()));
 
+            public KeyedVariable DeepCopy() => new KeyedVariable(Key == null ? null : GetStaticVariable(Key.GetValue().DeepCopy().value), GetStaticVariable(Value.GetValue().DeepCopy().value));
+
             String Wrap(String value) => value.Contains(" ") ? "\"" + value + "\"" : value;
 
             public override bool Equals(Object variable) => GetKey() == ((KeyedVariable)variable).GetKey() && Value.GetValue().value.Equals(((KeyedVariable)variable).Value.GetValue().value);


### PR DESCRIPTION
This commit fixes an issue where appending to lists previously would not keep static values but rather references.  This caused variable additions to be reference and have changing values.

Binding keyed indexes still works as expected but this fixes an issue where adding values was not working as expected.

This commit resolves #187 