### PR TITLE
Added support for Dynamic Function Execution

### DIFF
--- a/EasyCommands.Tests/EasyCommands.Tests.csproj
+++ b/EasyCommands.Tests/EasyCommands.Tests.csproj
@@ -172,6 +172,7 @@
     <Compile Include="ScriptTests\FunctionalTests\BlockHandlers\CargoBlockTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\BlockHandlers\ConnectorBlockTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\BlockHandlers\JumpDriveBlockTests.cs" />
+    <Compile Include="ScriptTests\FunctionalTests\Commands\FunctionCommandTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Commands\ControlCommandTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Commands\IterationCommandTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Commands\ListenCommandTests.cs" />

--- a/EasyCommands.Tests/ParameterParsingTests/SimpleCommandProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SimpleCommandProcessorTests.cs
@@ -56,7 +56,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             var command = program.ParseCommand("goto \"listen\"");
             Assert.IsTrue(command is FunctionCommand);
             FunctionCommand functionCommand = (FunctionCommand)command;
-            Assert.AreEqual("listen", functionCommand.functionDefinition.functionName);
+            Assert.AreEqual("listen", functionCommand.functionName());
             Assert.AreEqual(true, functionCommand.switchExecution);
         }
 
@@ -67,7 +67,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             var command = program.ParseCommand("\"listen\"");
             Assert.IsTrue(command is FunctionCommand);
             FunctionCommand functionCommand = (FunctionCommand)command;
-            Assert.AreEqual("listen", functionCommand.functionDefinition.functionName);
+            Assert.AreEqual("listen", functionCommand.functionName());
             Assert.AreEqual(false, functionCommand.switchExecution);
         }
 
@@ -78,7 +78,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             var command = program.ParseCommand("goto 'listen'");
             Assert.IsTrue(command is FunctionCommand);
             FunctionCommand functionCommand = (FunctionCommand)command;
-            Assert.AreEqual("listen", functionCommand.functionDefinition.functionName);
+            Assert.AreEqual("listen", functionCommand.functionName());
             Assert.AreEqual(true, functionCommand.switchExecution);
         }
 
@@ -89,10 +89,10 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             var command = program.ParseCommand("goto \"listen\" 2 3");
             Assert.IsTrue(command is FunctionCommand);
             FunctionCommand functionCommand = (FunctionCommand)command;
-            Assert.AreEqual("listen", functionCommand.functionDefinition.functionName);
+            Assert.AreEqual("listen", functionCommand.functionName());
             Assert.AreEqual(true, functionCommand.switchExecution);
-            Assert.AreEqual(2, CastNumber(functionCommand.inputParameters["a"].GetValue()));
-            Assert.AreEqual(3, CastNumber(functionCommand.inputParameters["b"].GetValue()));
+            Assert.AreEqual(2, CastNumber(functionCommand.inputParameters[0].GetValue()));
+            Assert.AreEqual(3, CastNumber(functionCommand.inputParameters[1].GetValue()));
         }
 
         [TestMethod]
@@ -102,10 +102,10 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             var command = program.ParseCommand("\"listen\" 2 3");
             Assert.IsTrue(command is FunctionCommand);
             FunctionCommand functionCommand = (FunctionCommand)command;
-            Assert.AreEqual("listen", functionCommand.functionDefinition.functionName);
+            Assert.AreEqual("listen", functionCommand.functionName());
             Assert.AreEqual(false, functionCommand.switchExecution);
-            Assert.AreEqual(2, CastNumber(functionCommand.inputParameters["a"].GetValue()));
-            Assert.AreEqual(3, CastNumber(functionCommand.inputParameters["b"].GetValue()));
+            Assert.AreEqual(2, CastNumber(functionCommand.inputParameters[0].GetValue()));
+            Assert.AreEqual(3, CastNumber(functionCommand.inputParameters[1].GetValue()));
         }
 
         [TestMethod]

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Commands/FunctionCommandTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Commands/FunctionCommandTests.cs
@@ -1,0 +1,340 @@
+﻿using System;
+using System.Collections.Generic;
+using IngameScript;
+using Malware.MDKUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Sandbox.ModAPI.Ingame;
+using SpaceEngineers.Game.ModAPI;
+using VRageMath;
+
+namespace EasyCommands.Tests.ScriptTests {
+    [TestClass]
+    public class FunctionCommandTests {
+        [TestMethod]
+        public void CallFunctionExplicitly() {
+            String script = @"
+:main
+call myFunction
+print ""Done""
+
+:myFunction
+print ""Hello World""
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.RunUntilDone();
+
+                Assert.AreEqual(2, test.Logger.Count);
+                Assert.AreEqual("Hello World", test.Logger[0]);
+                Assert.AreEqual("Done", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CallFunctionImplicitly() {
+            String script = @"
+:main
+myFunction
+print ""Done""
+
+:myFunction
+print ""Hello World""
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.RunUntilDone();
+
+                Assert.AreEqual(2, test.Logger.Count);
+                Assert.AreEqual("Hello World", test.Logger[0]);
+                Assert.AreEqual("Done", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void GotoFunction() {
+            String script = @"
+:main
+goto myFunction
+print ""Done""
+
+:myFunction
+print ""Hello World""
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.program.logLevel = Program.LogLevel.INFO;
+
+                test.RunOnce();
+                Assert.AreEqual(4, test.Logger.Count);
+                Assert.AreEqual("Queued Threads: 1", test.Logger[0]);
+                Assert.AreEqual("Async Threads: 0", test.Logger[1]);
+                Assert.AreEqual("[Main] main", test.Logger[2]);
+                Assert.AreEqual("Running", test.Logger[3]);
+
+                test.Logger.Clear();
+                test.RunUntilDone();
+
+                Assert.AreEqual(5, test.Logger.Count);
+                Assert.AreEqual("Queued Threads: 1", test.Logger[0]);
+                Assert.AreEqual("Async Threads: 0", test.Logger[1]);
+                Assert.AreEqual("[Main] myFunction", test.Logger[2]);
+                Assert.AreEqual("Hello World", test.Logger[3]);
+                Assert.AreEqual("Complete", test.Logger[4]);
+            }
+        }
+
+        [TestMethod]
+        public void CallFunctionExplicitlyWithVariableParameters() {
+            String script = @"
+:main
+set a to ""one""
+set b to ""two""
+
+call myFunction a b
+print ""Done""
+
+:myFunction param1 param2
+print ""Param1: "" + param1
+print ""Param2: "" + param2
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.RunUntilDone();
+
+                Assert.AreEqual(3, test.Logger.Count);
+                Assert.AreEqual("Param1: one", test.Logger[0]);
+                Assert.AreEqual("Param2: two", test.Logger[1]);
+                Assert.AreEqual("Done", test.Logger[2]);
+            }
+        }
+
+        [TestMethod]
+        public void CallFunctionImplicitlyWithVariableParameters() {
+            String script = @"
+:main
+set a to ""one""
+set b to ""two""
+
+myFunction a b
+print ""Done""
+
+:myFunction param1 param2
+print ""Param1: "" + param1
+print ""Param2: "" + param2
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.RunUntilDone();
+
+                Assert.AreEqual(3, test.Logger.Count);
+                Assert.AreEqual("Param1: one", test.Logger[0]);
+                Assert.AreEqual("Param2: two", test.Logger[1]);
+                Assert.AreEqual("Done", test.Logger[2]);
+            }
+        }
+
+        [TestMethod]
+        public void GotoFunctionWithVariableParameters() {
+            String script = @"
+:main
+set a to ""one""
+set b to ""two""
+
+goto myFunction a b
+print ""Done""
+
+:myFunction param1 param2
+print ""Param1: "" + param1
+print ""Param2: "" + param2
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.RunUntilDone();
+
+                Assert.AreEqual(2, test.Logger.Count);
+                Assert.AreEqual("Param1: one", test.Logger[0]);
+                Assert.AreEqual("Param2: two", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CallVariableFunction() {
+            String script = @"
+:main
+set myFunctionName to ""myFunction""
+
+call myFunctionName
+
+set myFunctionName to ""mySecondFunction""
+call myFunctionName
+
+print ""Done""
+
+:myFunction
+print ""Hello World""
+
+:mySecondFunction
+print ""How are your?""
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.RunUntilDone();
+
+                Assert.AreEqual(3, test.Logger.Count);
+                Assert.AreEqual("Hello World", test.Logger[0]);
+                Assert.AreEqual("How are your?", test.Logger[1]);
+                Assert.AreEqual("Done", test.Logger[2]);
+            }
+        }
+
+        [TestMethod]
+        public void GotoVariableFunction() {
+            String script = @"
+:main
+set myFunctionName to ""myFunction""
+
+goto myFunctionName
+print ""Done""
+
+:myFunction
+print ""Hello World""
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.RunUntilDone();
+
+                Assert.AreEqual(1, test.Logger.Count);
+                Assert.AreEqual("Hello World", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void CallVariableFunctionWithVariableParameters() {
+            String script = @"
+:main
+set a to ""one""
+set b to ""two""
+set myFunctionName to ""myFunction""
+call myFunctionName a b
+print ""Done""
+
+:myFunction param1 param2
+print ""Param1: "" + param1
+print ""Param2: "" + param2
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.RunUntilDone();
+
+                Assert.AreEqual(3, test.Logger.Count);
+                Assert.AreEqual("Param1: one", test.Logger[0]);
+                Assert.AreEqual("Param2: two", test.Logger[1]);
+                Assert.AreEqual("Done", test.Logger[2]);
+            }
+        }
+
+        [TestMethod]
+        public void GotoVariableFunctionWithVariableParameters() {
+            String script = @"
+:main
+set a to ""one""
+set b to ""two""
+set myFunctionName to ""myFunction""
+
+goto myFunctionName a b
+print ""Done""
+
+:myFunction param1 param2
+print ""Param1: "" + param1
+print ""Param2: "" + param2
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.RunUntilDone();
+
+                Assert.AreEqual(2, test.Logger.Count);
+                Assert.AreEqual("Param1: one", test.Logger[0]);
+                Assert.AreEqual("Param2: two", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CallInvalidFunction() {
+            String script = @"
+:main
+call myFunction
+print ""Done""
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.AreEqual(2, test.Logger.Count);
+                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Invalid Function Name: myFunction", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CallInvalidVariableFunction() {
+            String script = @"
+:main
+set myFunctionName to ""myFunction""
+
+call myFunctionName
+print ""Done""
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.AreEqual(2, test.Logger.Count);
+                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Invalid Function Name: myFunction", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CallFunctionWithIncorrectParameters() {
+            String script = @"
+:main
+call myFunction
+print ""Done""
+
+:myFunction a b
+print ""Hello World""
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.AreEqual(2, test.Logger.Count);
+                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Function myFunction expects 2 parameters", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CallVariableFunctionWithIncorrectParameters() {
+            String script = @"
+:main
+set myFunctionName to ""myFunction""
+
+call myFunctionName
+print ""Done""
+
+:myFunction a b
+print ""Hello World""
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.AreEqual(2, test.Logger.Count);
+                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Function myFunction expects 2 parameters", test.Logger[1]);
+            }
+        }
+    }
+}

--- a/EasyCommands/CommandParsers/ParameterProcessors.cs
+++ b/EasyCommands/CommandParsers/ParameterProcessors.cs
@@ -284,33 +284,33 @@ namespace IngameScript {
             }
         }
 
-        static RuleProcessor<T> NoValueRule<T>(Func<T> type, Convert<T> convert) where T : class, CommandParameter => NoValueRule(type, (p) => true, convert);
+        static RuleProcessor<T> NoValueRule<T>(Supplier<T> type, Convert<T> convert) where T : class, CommandParameter => NoValueRule(type, (p) => true, convert);
 
-        static RuleProcessor<T> NoValueRule<T>(Func<T> type, CanConvert<T> canConvert, Convert<T> convert) where T : class, CommandParameter =>
+        static RuleProcessor<T> NoValueRule<T>(Supplier<T> type, CanConvert<T> canConvert, Convert<T> convert) where T : class, CommandParameter =>
             new RuleProcessor<T>(NewList<DataProcessor>(), canConvert, convert);
 
-        static RuleProcessor<T> OneValueRule<T, U>(Func<T> type, DataProcessor<U> u, OneValueConvert<T, U> convert) where T : class, CommandParameter =>
+        static RuleProcessor<T> OneValueRule<T, U>(Supplier<T> type, DataProcessor<U> u, OneValueConvert<T, U> convert) where T : class, CommandParameter =>
             OneValueRule(type, u, (p, a) => a.Satisfied(), convert);
 
-        static RuleProcessor<T> OneValueRule<T, U>(Func<T> type, DataProcessor<U> u, OneValueCanConvert<T, U> canConvert, OneValueConvert<T, U> convert) where T : class, CommandParameter =>
+        static RuleProcessor<T> OneValueRule<T, U>(Supplier<T> type, DataProcessor<U> u, OneValueCanConvert<T, U> canConvert, OneValueConvert<T, U> convert) where T : class, CommandParameter =>
             new RuleProcessor<T>(NewList<DataProcessor>(u), (p) => canConvert(p, u), (p) => convert(p, u.GetValue()));
 
-        static RuleProcessor<T> TwoValueRule<T, U, V>(Func<T> type, DataProcessor<U> u, DataProcessor<V> v, TwoValueConvert<T, U, V> convert) where T : class, CommandParameter =>
+        static RuleProcessor<T> TwoValueRule<T, U, V>(Supplier<T> type, DataProcessor<U> u, DataProcessor<V> v, TwoValueConvert<T, U, V> convert) where T : class, CommandParameter =>
             TwoValueRule(type, u, v, (p, a, b) => AllSatisfied(a, b), convert);
 
-        static RuleProcessor<T> TwoValueRule<T, U, V>(Func<T> type, DataProcessor<U> u, DataProcessor<V> v, TwoValueCanConvert<T, U, V> canConvert, TwoValueConvert<T, U, V> convert) where T : class, CommandParameter =>
+        static RuleProcessor<T> TwoValueRule<T, U, V>(Supplier<T> type, DataProcessor<U> u, DataProcessor<V> v, TwoValueCanConvert<T, U, V> canConvert, TwoValueConvert<T, U, V> convert) where T : class, CommandParameter =>
             new RuleProcessor<T>(NewList<DataProcessor>(u, v), (p) => canConvert(p, u, v), (p) => convert(p, u.GetValue(), v.GetValue()));
 
-        static RuleProcessor<T> ThreeValueRule<T, U, V, W>(Func<T> type, DataProcessor<U> u, DataProcessor<V> v, DataProcessor<W> w, ThreeValueConvert<T, U, V, W> convert) where T : class, CommandParameter =>
+        static RuleProcessor<T> ThreeValueRule<T, U, V, W>(Supplier<T> type, DataProcessor<U> u, DataProcessor<V> v, DataProcessor<W> w, ThreeValueConvert<T, U, V, W> convert) where T : class, CommandParameter =>
             ThreeValueRule(type, u, v, w, (p, a, b, c) => AllSatisfied(a, b, c), convert);
 
-        static RuleProcessor<T> ThreeValueRule<T, U, V, W>(Func<T> type, DataProcessor<U> u, DataProcessor<V> v, DataProcessor<W> w, ThreeValueCanConvert<T, U, V, W> canConvert, ThreeValueConvert<T, U, V, W> convert) where T : class, CommandParameter =>
+        static RuleProcessor<T> ThreeValueRule<T, U, V, W>(Supplier<T> type, DataProcessor<U> u, DataProcessor<V> v, DataProcessor<W> w, ThreeValueCanConvert<T, U, V, W> canConvert, ThreeValueConvert<T, U, V, W> convert) where T : class, CommandParameter =>
             new RuleProcessor<T>(NewList<DataProcessor>(u, v, w), p => canConvert(p, u, v, w), p => convert(p, u.GetValue(), v.GetValue(), w.GetValue()));
 
-        static RuleProcessor<T> FourValueRule<T, U, V, W, X>(Func<T> type, DataProcessor<U> u, DataProcessor<V> v, DataProcessor<W> w, DataProcessor<X> x, FourValueConvert<T, U, V, W, X> convert) where T : class, CommandParameter =>
+        static RuleProcessor<T> FourValueRule<T, U, V, W, X>(Supplier<T> type, DataProcessor<U> u, DataProcessor<V> v, DataProcessor<W> w, DataProcessor<X> x, FourValueConvert<T, U, V, W, X> convert) where T : class, CommandParameter =>
             FourValueRule(type, u, v, w, x, (p, a, b, c, d) => AllSatisfied(a, b, c, d), convert);
 
-        static RuleProcessor<T> FourValueRule<T, U, V, W, X>(Func<T> type, DataProcessor<U> u, DataProcessor<V> v, DataProcessor<W> w, DataProcessor<X> x, FourValueCanConvert<T, U, V, W, X> canConvert, FourValueConvert<T, U, V, W, X> convert) where T : class, CommandParameter =>
+        static RuleProcessor<T> FourValueRule<T, U, V, W, X>(Supplier<T> type, DataProcessor<U> u, DataProcessor<V> v, DataProcessor<W> w, DataProcessor<X> x, FourValueCanConvert<T, U, V, W, X> canConvert, FourValueConvert<T, U, V, W, X> convert) where T : class, CommandParameter =>
             new RuleProcessor<T>(NewList<DataProcessor>(u, v, w, x), p => canConvert(p, u, v, w, x), p => convert(p, u.GetValue(), v.GetValue(), w.GetValue(), x.GetValue()));
 
         //Utility delegates to efficiently create Rule Processors
@@ -325,7 +325,5 @@ namespace IngameScript {
         delegate object TwoValueConvert<T, U, V>(T t, U a, V b);
         delegate object ThreeValueConvert<T, U, V, W>(T t, U a, V b, W c);
         delegate object FourValueConvert<T, U, V, W, X>(T t, U a, V b, W c, X d);
-
-        static T Type<T>() => default(T);
     }
 }

--- a/EasyCommands/Commands/CommandParameters.cs
+++ b/EasyCommands/Commands/CommandParameters.cs
@@ -173,9 +173,9 @@ namespace IngameScript {
 
         public class FunctionDefinitionCommandParameter : SimpleCommandParameter {
             public bool switchExecution;
-            public FunctionDefinition functionDefinition;
+            public Supplier<string> functionDefinition;
 
-            public FunctionDefinitionCommandParameter(FunctionDefinition definition, bool shouldSwitch = false) {
+            public FunctionDefinitionCommandParameter(Supplier<string> definition, bool shouldSwitch = false) {
                 switchExecution = shouldSwitch;
                 functionDefinition = definition;
             }

--- a/EasyCommands/Common/Utilities.cs
+++ b/EasyCommands/Common/Utilities.cs
@@ -1,0 +1,25 @@
+﻿using Sandbox.Game.EntityComponents;
+using Sandbox.ModAPI.Ingame;
+using Sandbox.ModAPI.Interfaces;
+using SpaceEngineers.Game.ModAPI.Ingame;
+using System.Collections.Generic;
+using System.Collections;
+using System.Linq;
+using System.Text;
+using System;
+using VRage.Collections;
+using VRage.Game.Components;
+using VRage.Game.GUI.TextPanel;
+using VRage.Game.ModAPI.Ingame.Utilities;
+using VRage.Game.ModAPI.Ingame;
+using VRage.Game.ObjectBuilders.Definitions;
+using VRage.Game;
+using VRage;
+using VRageMath;
+
+namespace IngameScript {
+    partial class Program {
+        static T Type<T>() => default(T);
+        public delegate T Supplier<T>();
+    }
+}

--- a/EasyCommands/EasyCommands.csproj
+++ b/EasyCommands/EasyCommands.csproj
@@ -177,6 +177,7 @@
     <Compile Include="Common\Conditions.cs" />
     <Compile Include="Common\Primitives.cs" />
     <Compile Include="Common\Properties.cs" />
+    <Compile Include="Common\Utilities.cs" />
     <Compile Include="Common\Types.cs" />
     <Compile Include="Common\Variables.cs" />
     <Compile Include="MDK\Bootstrapper.cs" />

--- a/docs/EasyCommands/functions.md
+++ b/docs/EasyCommands/functions.md
@@ -59,6 +59,37 @@ goto "myFunction2"
 
 This is effectively changing what function is currently considered "active" by the program.  The current function, no matter its state of execution, is abandoned in favor of the new active program.  Furthermore, any commands to "restart", "loop", "start" will now restart the new function.  This behavior effectively enables "modes" for your program to run in where the modes are intended to be exclusive. 
 
+### Calling Functions Dynamically
+It is possible to invoke a named function using a variable specifying the name of the function to invoke by explicitly using ```call``` or ```goto```.  This provides an easy way to create modes for your program.  Make sure to pass the same number of parameters to the function you intend to invoke.
+
+```
+set global runningFunction to "attack"
+
+#Spin off a separate thread that's actually running the program
+async runProgram
+
+#Tie this to a button
+:switchMode mode
+set global runningFunction to mode
+
+#Dynamically resolve the function to call using the runningFunction variable
+:runProgram
+call runningFunction
+replay
+
+#Mode 1
+:attack
+Print "Attacking the enemy!"
+
+#Mode 2
+:flee
+Print "Fleeing!"
+```
+
+Note that since the function to call isn't known until your script is executing, you won't be told about potentially invalid function calls during parsing.  
+
+If you try to invoke a function that is not defined, or try to invoke a defined function with the wrong number of parameters, you will get a script halting exception.
+
 ## Returning from a function
 Sometimes you might want to return from a function early (meaning if some condition is met, short circuit).  You can return from a function using the ```return``` keywords.
 


### PR DESCRIPTION
This commit adds the ability to invoke functions dynamically using variables.  This is a powerful feature, but comes at the cost of compile time safety.

This commit moves the resolution of the function name to invoke to a runtime call.  It also leaves the resolution of parameter key names to runtime.  The existing
error messages have been improved, but will now show up as runtime exceptions.

Lastly, this commit introduces a "Utilities" section to contain some useful utilities for saving characters on Type and Function declarations.

This commit resolves #172 