### PR TITLE
Small Changes

### DIFF
--- a/EasyCommands.Tests/ParameterParsingTests/OperatorParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/OperatorParameterProcessorTests.cs
@@ -144,6 +144,18 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         }
 
         [TestMethod]
+        public void AssignRoundVector() {
+            var program = MDKFactory.CreateProgram<Program>();
+            var command = program.ParseCommand("assign a to round (5.6:0:5.4)");
+            Assert.IsTrue(command is VariableAssignmentCommand);
+            VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
+            Assert.IsTrue(assignment.variable is UniOperandVariable);
+            UniOperandVariable variable = (UniOperandVariable)assignment.variable;
+            Assert.AreEqual(UniOperand.ROUND, variable.operand);
+            Assert.AreEqual(new Vector3D(6f, 0f, 5f), CastVector(variable.GetValue()));
+        }
+
+        [TestMethod]
         public void AssignAbsoluteValueVector() {
             var program = MDKFactory.CreateProgram<Program>();
             var command = program.ParseCommand("assign a to abs \"1:0:0\" + 2");

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/GyroscopeBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/GyroscopeBlockTests.cs
@@ -4,6 +4,7 @@ using Moq;
 using Sandbox.ModAPI.Ingame;
 using VRageMath;
 using static EasyCommands.Tests.ScriptTests.MockEntityUtility;
+using static IngameScript.Program;
 
 namespace EasyCommands.Tests.ScriptTests {
     [TestClass]
@@ -85,9 +86,9 @@ namespace EasyCommands.Tests.ScriptTests {
         public void GetGyroscopeRotationVector() {
             using (var test = new ScriptTest(@"Print ""Rotation: "" + the ""test gyro"" rotation")) {
                 var mockGyro = new Mock<IMyGyro>();
-                MockGetProperty(mockGyro, "Pitch", 1f);
-                MockGetProperty(mockGyro, "Yaw", 2f);
-                MockGetProperty(mockGyro, "Roll", 3f);
+                mockGyro.Setup(b => b.Pitch).Returns(RPMToRadiansPerSec * 1f);
+                mockGyro.Setup(b => b.Yaw).Returns(RPMToRadiansPerSec * 2f);
+                mockGyro.Setup(b => b.Roll).Returns(RPMToRadiansPerSec * 3f);
                 test.MockBlocksOfType("test gyro", mockGyro);
 
                 test.RunUntilDone();
@@ -100,16 +101,13 @@ namespace EasyCommands.Tests.ScriptTests {
         public void SetGyroscopeRotationVector() {
             using (var test = new ScriptTest(@"set the ""test gyro"" rotation to 1:2:3")) {
                 var mockGyro = new Mock<IMyGyro>();
-                var mockPitch = MockProperty<IMyGyro, float>(mockGyro, "Pitch");
-                var mockYaw = MockProperty<IMyGyro, float>(mockGyro, "Yaw");
-                var mockRoll = MockProperty<IMyGyro, float>(mockGyro, "Roll");
                 test.MockBlocksOfType("test gyro", mockGyro);
 
                 test.RunUntilDone();
 
-                mockPitch.Verify(p => p.SetValue(mockGyro.Object, 1f));
-                mockYaw.Verify(p => p.SetValue(mockGyro.Object, 2f));
-                mockRoll.Verify(p => p.SetValue(mockGyro.Object, 3f));
+                mockGyro.VerifySet(b => b.Pitch = RPMToRadiansPerSec * 1f);
+                mockGyro.VerifySet(b => b.Yaw = RPMToRadiansPerSec * 2f);
+                mockGyro.VerifySet(b => b.Roll = RPMToRadiansPerSec * 3f);
             }
         }
 
@@ -117,7 +115,7 @@ namespace EasyCommands.Tests.ScriptTests {
         public void GetGyroscopePitch() {
             using (var test = new ScriptTest(@"Print ""Pitch: "" + the ""test gyro"" upwards rotation")) {
                 var mockGyro = new Mock<IMyGyro>();
-                MockGetProperty(mockGyro, "Pitch", 5f);
+                mockGyro.Setup(b => b.Pitch).Returns(RPMToRadiansPerSec * 5f);
                 test.MockBlocksOfType("test gyro", mockGyro);
 
                 test.RunUntilDone();
@@ -130,11 +128,10 @@ namespace EasyCommands.Tests.ScriptTests {
         public void SetGyroscopePitch() {
             using (var test = new ScriptTest(@"set the ""test gyro"" upwards rotation to 10")) {
                 var mockGyro = new Mock<IMyGyro>();
-                var mockPitch = MockProperty<IMyGyro, float>(mockGyro, "Pitch");
                 test.MockBlocksOfType("test gyro", mockGyro);
                 test.RunUntilDone();
 
-                mockPitch.Verify(p => p.SetValue(mockGyro.Object, 10f));
+                mockGyro.VerifySet(b => b.Pitch = RPMToRadiansPerSec * 10f);
             }
         }
 
@@ -142,7 +139,7 @@ namespace EasyCommands.Tests.ScriptTests {
         public void GetGyroscopeInversePitch() {
             using (var test = new ScriptTest(@"Print ""Pitch: "" + the ""test gyro"" downwards rotation")) {
                 var mockGyro = new Mock<IMyGyro>();
-                MockGetProperty(mockGyro, "Pitch", 5f);
+                mockGyro.Setup(b => b.Pitch).Returns(RPMToRadiansPerSec * 5f);
                 test.MockBlocksOfType("test gyro", mockGyro);
 
                 test.RunUntilDone();
@@ -155,11 +152,10 @@ namespace EasyCommands.Tests.ScriptTests {
         public void SetGyroscopeInversePitch() {
             using (var test = new ScriptTest(@"set the ""test gyro"" downwards rotation to 10")) {
                 var mockGyro = new Mock<IMyGyro>();
-                var mockPitch = MockProperty<IMyGyro, float>(mockGyro, "Pitch");
                 test.MockBlocksOfType("test gyro", mockGyro);
                 test.RunUntilDone();
 
-                mockPitch.Verify(p => p.SetValue(mockGyro.Object, -10f));
+                mockGyro.VerifySet(b => b.Pitch = RPMToRadiansPerSec * -10f);
             }
         }
 
@@ -167,7 +163,7 @@ namespace EasyCommands.Tests.ScriptTests {
         public void GetGyroscopeYaw() {
             using (var test = new ScriptTest(@"Print ""Yaw: "" + the ""test gyro"" right rotation")) {
                 var mockGyro = new Mock<IMyGyro>();
-                MockGetProperty(mockGyro, "Yaw", 5f);
+                mockGyro.Setup(b => b.Yaw).Returns(RPMToRadiansPerSec * 5f);
                 test.MockBlocksOfType("test gyro", mockGyro);
 
                 test.RunUntilDone();
@@ -180,11 +176,10 @@ namespace EasyCommands.Tests.ScriptTests {
         public void SetGyroscopeYaw() {
             using (var test = new ScriptTest(@"set the ""test gyro"" right rotation to 10")) {
                 var mockGyro = new Mock<IMyGyro>();
-                var mockYaw = MockProperty<IMyGyro, float>(mockGyro, "Yaw");
                 test.MockBlocksOfType("test gyro", mockGyro);
                 test.RunUntilDone();
 
-                mockYaw.Verify(p => p.SetValue(mockGyro.Object, 10f));
+                mockGyro.VerifySet(b => b.Yaw = RPMToRadiansPerSec * 10f);
             }
         }
 
@@ -192,7 +187,7 @@ namespace EasyCommands.Tests.ScriptTests {
         public void GetGyroscopeInverseYaw() {
             using (var test = new ScriptTest(@"Print ""Yaw: "" + the ""test gyro"" left rotation")) {
                 var mockGyro = new Mock<IMyGyro>();
-                MockGetProperty(mockGyro, "Yaw", 5f);
+                mockGyro.Setup(b => b.Yaw).Returns(RPMToRadiansPerSec * 5f);
                 test.MockBlocksOfType("test gyro", mockGyro);
 
                 test.RunUntilDone();
@@ -205,11 +200,10 @@ namespace EasyCommands.Tests.ScriptTests {
         public void SetGyroscopeInverseYaw() {
             using (var test = new ScriptTest(@"set the ""test gyro"" left rotation to 10")) {
                 var mockGyro = new Mock<IMyGyro>();
-                var mockYaw = MockProperty<IMyGyro, float>(mockGyro, "Yaw");
                 test.MockBlocksOfType("test gyro", mockGyro);
                 test.RunUntilDone();
 
-                mockYaw.Verify(p => p.SetValue(mockGyro.Object, -10f));
+                mockGyro.VerifySet(b => b.Yaw = RPMToRadiansPerSec * -10f);
             }
         }
 
@@ -217,7 +211,7 @@ namespace EasyCommands.Tests.ScriptTests {
         public void GetGyroscopeRoll() {
             using (var test = new ScriptTest(@"Print ""Roll: "" + the ""test gyro"" clockwise rotation")) {
                 var mockGyro = new Mock<IMyGyro>();
-                MockGetProperty(mockGyro, "Roll", 5f);
+                mockGyro.Setup(b => b.Roll).Returns(RPMToRadiansPerSec * 5f);
                 test.MockBlocksOfType("test gyro", mockGyro);
 
                 test.RunUntilDone();
@@ -230,11 +224,10 @@ namespace EasyCommands.Tests.ScriptTests {
         public void SetGyroscopeRoll() {
             using (var test = new ScriptTest(@"set the ""test gyro"" clockwise rotation to 10")) {
                 var mockGyro = new Mock<IMyGyro>();
-                var mockRoll = MockProperty<IMyGyro, float>(mockGyro, "Roll");
                 test.MockBlocksOfType("test gyro", mockGyro);
                 test.RunUntilDone();
 
-                mockRoll.Verify(p => p.SetValue(mockGyro.Object, 10f));
+                mockGyro.VerifySet(b => b.Roll = RPMToRadiansPerSec * 10f);
             }
         }
 
@@ -242,7 +235,7 @@ namespace EasyCommands.Tests.ScriptTests {
         public void GetGyroscopeInverseRoll() {
             using (var test = new ScriptTest(@"Print ""Roll: "" + the ""test gyro"" counter rotation")) {
                 var mockGyro = new Mock<IMyGyro>();
-                MockGetProperty(mockGyro, "Roll", 5f);
+                mockGyro.Setup(b => b.Roll).Returns(RPMToRadiansPerSec * 5f);
                 test.MockBlocksOfType("test gyro", mockGyro);
 
                 test.RunUntilDone();
@@ -255,11 +248,10 @@ namespace EasyCommands.Tests.ScriptTests {
         public void SetGyroscopeInverseRoll() {
             using (var test = new ScriptTest(@"set the ""test gyro"" counter rotation to 10")) {
                 var mockGyro = new Mock<IMyGyro>();
-                var mockRoll = MockProperty<IMyGyro, float>(mockGyro, "Roll");
                 test.MockBlocksOfType("test gyro", mockGyro);
                 test.RunUntilDone();
 
-                mockRoll.Verify(p => p.SetValue(mockGyro.Object, -10f));
+                mockGyro.VerifySet(b => b.Roll = RPMToRadiansPerSec * -10f);
             }
         }
     }

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/GyroscopeBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/GyroscopeBlockTests.cs
@@ -86,7 +86,7 @@ namespace EasyCommands.Tests.ScriptTests {
         public void GetGyroscopeRotationVector() {
             using (var test = new ScriptTest(@"Print ""Rotation: "" + the ""test gyro"" rotation")) {
                 var mockGyro = new Mock<IMyGyro>();
-                mockGyro.Setup(b => b.Pitch).Returns(RPMToRadiansPerSec * 1f);
+                mockGyro.Setup(b => b.Pitch).Returns(RPMToRadiansPerSec * -1f);
                 mockGyro.Setup(b => b.Yaw).Returns(RPMToRadiansPerSec * 2f);
                 mockGyro.Setup(b => b.Roll).Returns(RPMToRadiansPerSec * 3f);
                 test.MockBlocksOfType("test gyro", mockGyro);
@@ -105,7 +105,7 @@ namespace EasyCommands.Tests.ScriptTests {
 
                 test.RunUntilDone();
 
-                mockGyro.VerifySet(b => b.Pitch = RPMToRadiansPerSec * 1f);
+                mockGyro.VerifySet(b => b.Pitch = RPMToRadiansPerSec * -1f);
                 mockGyro.VerifySet(b => b.Yaw = RPMToRadiansPerSec * 2f);
                 mockGyro.VerifySet(b => b.Roll = RPMToRadiansPerSec * 3f);
             }
@@ -115,7 +115,7 @@ namespace EasyCommands.Tests.ScriptTests {
         public void GetGyroscopePitch() {
             using (var test = new ScriptTest(@"Print ""Pitch: "" + the ""test gyro"" upwards rotation")) {
                 var mockGyro = new Mock<IMyGyro>();
-                mockGyro.Setup(b => b.Pitch).Returns(RPMToRadiansPerSec * 5f);
+                mockGyro.Setup(b => b.Pitch).Returns(RPMToRadiansPerSec * -5f);
                 test.MockBlocksOfType("test gyro", mockGyro);
 
                 test.RunUntilDone();
@@ -131,7 +131,7 @@ namespace EasyCommands.Tests.ScriptTests {
                 test.MockBlocksOfType("test gyro", mockGyro);
                 test.RunUntilDone();
 
-                mockGyro.VerifySet(b => b.Pitch = RPMToRadiansPerSec * 10f);
+                mockGyro.VerifySet(b => b.Pitch = RPMToRadiansPerSec * -10f);
             }
         }
 
@@ -139,7 +139,7 @@ namespace EasyCommands.Tests.ScriptTests {
         public void GetGyroscopeInversePitch() {
             using (var test = new ScriptTest(@"Print ""Pitch: "" + the ""test gyro"" downwards rotation")) {
                 var mockGyro = new Mock<IMyGyro>();
-                mockGyro.Setup(b => b.Pitch).Returns(RPMToRadiansPerSec * 5f);
+                mockGyro.Setup(b => b.Pitch).Returns(RPMToRadiansPerSec * -5f);
                 test.MockBlocksOfType("test gyro", mockGyro);
 
                 test.RunUntilDone();
@@ -155,7 +155,7 @@ namespace EasyCommands.Tests.ScriptTests {
                 test.MockBlocksOfType("test gyro", mockGyro);
                 test.RunUntilDone();
 
-                mockGyro.VerifySet(b => b.Pitch = RPMToRadiansPerSec * -10f);
+                mockGyro.VerifySet(b => b.Pitch = RPMToRadiansPerSec * 10f);
             }
         }
 

--- a/EasyCommands/BlockHandlers/GyroscopeBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/GyroscopeBlockHandlers.cs
@@ -29,15 +29,15 @@ namespace IngameScript {
 
                 var overrideHandler = DirectionalTypedHandler(Direction.NONE,
                         TypeHandler(ReturnTypedHandler(Return.VECTOR,
-                            TypeHandler(VectorHandler(b => new Vector3D(b.Pitch * RadiansPerSecToRPM, b.Yaw * RadiansPerSecToRPM, b.Roll * RadiansPerSecToRPM), (b, v) => {
-                                b.Pitch = RPMToRadiansPerSec * (float)v.X;
+                            TypeHandler(VectorHandler(b => new Vector3D(-b.Pitch * RadiansPerSecToRPM, b.Yaw * RadiansPerSecToRPM, b.Roll * RadiansPerSecToRPM), (b, v) => {
+                                b.Pitch = RPMToRadiansPerSec * (float)-v.X;
                                 b.Yaw = RPMToRadiansPerSec * (float)v.Y;
                                 b.Roll = RPMToRadiansPerSec * (float)v.Z;
                             }), Return.VECTOR),
                             TypeHandler(BooleanHandler(b => b.GyroOverride, (b, v) => b.GyroOverride = v), Return.BOOLEAN))
                         , Direction.NONE),
-                        TypeHandler(NumericHandler(b => RadiansPerSecToRPM * b.Pitch, (b, v) => b.Pitch = RPMToRadiansPerSec * v, 5), Direction.UP),
-                        TypeHandler(NumericHandler(b => RadiansPerSecToRPM * -b.Pitch, (b, v) => b.Pitch = RPMToRadiansPerSec * -v, 5), Direction.DOWN),
+                        TypeHandler(NumericHandler(b => RadiansPerSecToRPM * -b.Pitch, (b, v) => b.Pitch = RPMToRadiansPerSec * -v, 5), Direction.UP),
+                        TypeHandler(NumericHandler(b => RadiansPerSecToRPM * b.Pitch, (b, v) => b.Pitch = RPMToRadiansPerSec * v, 5), Direction.DOWN),
                         TypeHandler(NumericHandler(b => RadiansPerSecToRPM * -b.Yaw, (b, v) => b.Yaw = RPMToRadiansPerSec * -v, 5), Direction.LEFT),
                         TypeHandler(NumericHandler(b => RadiansPerSecToRPM * b.Yaw, (b, v) => b.Yaw = RPMToRadiansPerSec * v, 5), Direction.RIGHT),
                         TypeHandler(NumericHandler(b => RadiansPerSecToRPM * b.Roll, (b, v) => b.Roll = RPMToRadiansPerSec * v, 5), Direction.CLOCKWISE),

--- a/EasyCommands/BlockHandlers/GyroscopeBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/GyroscopeBlockHandlers.cs
@@ -29,19 +29,19 @@ namespace IngameScript {
 
                 var overrideHandler = DirectionalTypedHandler(Direction.NONE,
                         TypeHandler(ReturnTypedHandler(Return.VECTOR,
-                            TypeHandler(VectorHandler(b => new Vector3D(GetPitch(b), GetYaw(b), GetRoll(b)), (b, v) => {
-                                SetPitch(b, (float)v.X);
-                                SetYaw(b, (float)v.Y);
-                                SetRoll(b, (float)v.Z);
+                            TypeHandler(VectorHandler(b => new Vector3D(b.Pitch * RadiansPerSecToRPM, b.Yaw * RadiansPerSecToRPM, b.Roll * RadiansPerSecToRPM), (b, v) => {
+                                b.Pitch = RPMToRadiansPerSec * (float)v.X;
+                                b.Yaw = RPMToRadiansPerSec * (float)v.Y;
+                                b.Roll = RPMToRadiansPerSec * (float)v.Z;
                             }), Return.VECTOR),
                             TypeHandler(BooleanHandler(b => b.GyroOverride, (b, v) => b.GyroOverride = v), Return.BOOLEAN))
                         , Direction.NONE),
-                        TypeHandler(NumericHandler(GetPitch, SetPitch, 5), Direction.UP),
-                        TypeHandler(NumericHandler(b => -GetPitch(b), (b, v) => SetPitch(b, -v), 5), Direction.DOWN),
-                        TypeHandler(NumericHandler(b => -GetYaw(b), (b, v) => SetYaw(b, -v), 5), Direction.LEFT),
-                        TypeHandler(NumericHandler(GetYaw, SetYaw, 5), Direction.RIGHT),
-                        TypeHandler(NumericHandler(GetRoll, SetRoll, 5), Direction.CLOCKWISE),
-                        TypeHandler(NumericHandler(b => -GetRoll(b), (b, v) => SetRoll(b, -v), 5), Direction.COUNTERCLOCKWISE));
+                        TypeHandler(NumericHandler(b => RadiansPerSecToRPM * b.Pitch, (b, v) => b.Pitch = RPMToRadiansPerSec * v, 5), Direction.UP),
+                        TypeHandler(NumericHandler(b => RadiansPerSecToRPM * -b.Pitch, (b, v) => b.Pitch = RPMToRadiansPerSec * -v, 5), Direction.DOWN),
+                        TypeHandler(NumericHandler(b => RadiansPerSecToRPM * -b.Yaw, (b, v) => b.Yaw = RPMToRadiansPerSec * -v, 5), Direction.LEFT),
+                        TypeHandler(NumericHandler(b => RadiansPerSecToRPM * b.Yaw, (b, v) => b.Yaw = RPMToRadiansPerSec * v, 5), Direction.RIGHT),
+                        TypeHandler(NumericHandler(b => RadiansPerSecToRPM * b.Roll, (b, v) => b.Roll = RPMToRadiansPerSec * v, 5), Direction.CLOCKWISE),
+                        TypeHandler(NumericHandler(b => RadiansPerSecToRPM * -b.Roll, (b, v) => b.Roll = RPMToRadiansPerSec * -v, 5), Direction.COUNTERCLOCKWISE));
 
                 AddPropertyHandler(Property.OVERRIDE, overrideHandler);
                 AddPropertyHandler(Property.ROLL_INPUT, overrideHandler);
@@ -50,14 +50,6 @@ namespace IngameScript {
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.POWER;
                 defaultPropertiesByPrimitive[Return.VECTOR] = Property.OVERRIDE;
             }
-
-            float GetPitch(IMyGyro block) => block.GetValueFloat("Pitch");
-            float GetYaw(T block) => block.GetValueFloat("Yaw");
-            float GetRoll(T block) => block.GetValueFloat("Roll");
-
-            void SetPitch(T block, float value) => block.SetValueFloat("Pitch", value);
-            void SetYaw(T block, float value) => block.SetValueFloat("Yaw", value);
-            void SetRoll(T block, float value) => block.SetValueFloat("Roll", value);
         }
     }
 }

--- a/EasyCommands/Common/Collections.cs
+++ b/EasyCommands/Common/Collections.cs
@@ -19,11 +19,9 @@ using VRageMath;
 
 namespace IngameScript {
     partial class Program {
-        //Utilities for constructing collections with few characters
-        static List<T> NewList<T>(params T[] elements) => new List<T>(elements);
-        static KeyedList NewKeyedList(IEnumerable<Variable> values = null) => new KeyedList { keyedValues = NewList((values ?? NewList<Variable>()).ToArray()).ConvertAll(AsKeyedVariable)};
-        static Dictionary<T, U> NewDictionary<T, U>(params KeyValuePair<T, U>[] elements) => elements.ToDictionary(e => e.Key, e => e.Value);
-        static KeyValuePair<T, U> KeyValuePair<T, U>(T key, U value) => new KeyValuePair<T, U>(key, value);
+
+        static KeyedList NewKeyedList(IEnumerable<Variable> values = null) =>
+            new KeyedList { keyedValues = NewList((values ?? NewList<Variable>()).ToArray()).ConvertAll(AsKeyedVariable) };
 
         public class KeyedList {
             public List<KeyedVariable> keyedValues;

--- a/EasyCommands/Common/Operations.cs
+++ b/EasyCommands/Common/Operations.cs
@@ -139,6 +139,7 @@ namespace IngameScript {
 
             //Vector
             AddUniOperation<Vector3D>(UniOperand.SIGN, a => Vector3D.Sign(a));
+            AddUniOperation<Vector3D>(UniOperand.ROUND, a => Vector3D.Round(a, 0));
             AddUniOperation<Vector3D>(UniOperand.REVERSE, a => -a);
             AddBiOperation<Vector3D, Vector3D>(BiOperand.ADD, (a,b) => a + b);
             AddBiOperation<Vector3D, Vector3D>(BiOperand.SUBTRACT, (a, b) => a - b);

--- a/EasyCommands/Common/Utilities.cs
+++ b/EasyCommands/Common/Utilities.cs
@@ -20,6 +20,12 @@ using VRageMath;
 namespace IngameScript {
     partial class Program {
         static T Type<T>() => default(T);
+
         public delegate T Supplier<T>();
+
+        //Utilities for constructing collections with few characters
+        static List<T> NewList<T>(params T[] elements) => new List<T>(elements);
+        static Dictionary<T, U> NewDictionary<T, U>(params KeyValuePair<T, U>[] elements) => elements.ToDictionary(e => e.Key, e => e.Value);
+        static KeyValuePair<T, U> KeyValuePair<T, U>(T key, U value) => new KeyValuePair<T, U>(key, value);
     }
 }

--- a/EasyCommands/Common/Utilities.cs
+++ b/EasyCommands/Common/Utilities.cs
@@ -19,6 +19,9 @@ using VRageMath;
 
 namespace IngameScript {
     partial class Program {
+        public const float RPMToRadiansPerSec = (float)Math.PI / 30f;
+        public const float RadiansPerSecToRPM = 30f / (float)Math.PI;
+
         static T Type<T>() => default(T);
 
         public delegate T Supplier<T>();

--- a/docs/EasyCommands/blockHandlers/cockpit.md
+++ b/docs/EasyCommands/blockHandlers/cockpit.md
@@ -212,7 +212,7 @@ if "My Cockpit" left input > 0
 * Takes an optional Direction attribute
 * Keywords: ```roll, rolls, rollInput, rollInputs, rotation, rotations```
 
-If a direction is not included, Returns a Vector (Down:Right:Clockwise) representing the magnitude of rotation input (values between 0 - 1) from the engineer sitting in the cockpit.
+If a direction is not included, Returns a Vector (Up:Right:Clockwise) representing the magnitude of rotation input (values between 0 - 1) from the engineer sitting in the cockpit.
 
 If a direction is included, then returns a value between 0 - 1 representing the user roll input in the specified direction.
 Specifically, this input is mapped to WASDC + Space for the 6 input directions (not including rotation).

--- a/docs/EasyCommands/blockHandlers/gyroscope.md
+++ b/docs/EasyCommands/blockHandlers/gyroscope.md
@@ -66,7 +66,7 @@ set "My Gyro" limit to 0.5
 ## "Roll" Property
 * Primitive Type: Vector / Numeric / Bool
 * Keywords: ```roll, rollInput, rotation```
-* Supports Directions (Left, Right, Up, Down, Clockwise, CounterClockwise)
+* Supports Directions (Up, Down, Left, Right, Clockwise, CounterClockwise)
 
 This is useful for automatically adjusting your orientation based on some other inputs.
 
@@ -74,7 +74,7 @@ If a direction is given, expects a Numeric and Gets/Sets the Gyro override in th
 
 If no direction is given and a boolean is given, Gets/Sets whether Gyro Overrides are enabled.
 
-If no direction is given and a vector is given, Gets/Sets the Gyro Overrides (Yaw:Pitch:Roll).
+If no direction is given and a vector is given, Gets/Sets the Gyro Overrides (Pitch:Yaw:Roll).
 
 If no direction is given and no type is given, vector is assumed.
 

--- a/docs/EasyCommands/operations.md
+++ b/docs/EasyCommands/operations.md
@@ -199,9 +199,12 @@ set myReversedList to reversed myList
 ```
 
 ### Round
-Rounds the given number to the nearest integer (half-up)
+Behavior varies based on input types.
 
 Keywords: ```round, rnd```
+
+* **(Number)**: Rounds the given number to the nearest integer (half-up)
+* **(Vector)**: Rounds each vector component to the nearest integer (half-up)
 
 ### Shuffle
 Shuffles the given list.  This does not modify the input list but rather returns a shuffled copy of the input list.


### PR DESCRIPTION
* add `round` operator for vectors
* move some function from Collections.cs to Utilities.cs
* use gyro properties directly again and introduce constant for conversion from RPM to rad/s and viceversa
    each vector component is seperatly multiplied by the conversion factors so the test does not fail because of float to double promotion.
    