### PR TITLE
Updated Velocity properties to use vectors

### DIFF
--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/CockpitBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/CockpitBlockTests.cs
@@ -269,11 +269,24 @@ namespace EasyCommands.Tests.ScriptTests {
             using (ScriptTest test = new ScriptTest(@"Print ""Velocity: "" + the ""test cockpit"" velocity")) {
                 Mock<IMyCockpit> mockCockpit = new Mock<IMyCockpit>();
                 test.MockBlocksOfType("test cockpit", mockCockpit);
-                mockCockpit.Setup(b => b.GetShipSpeed()).Returns(100);
+                MockShipVelocities(mockCockpit, new Vector3D(2, 3, 6), Vector3D.Zero);
 
                 test.RunUntilDone();
 
-                Assert.AreEqual("Velocity: 100", test.Logger[0]);
+                Assert.AreEqual("Velocity: 2:3:6", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void GetTheCockpitVelocityNumeric() {
+            using (ScriptTest test = new ScriptTest(@"Print ""Velocity is 7: "" + the ""test cockpit"" velocity is 7")) {
+                Mock<IMyCockpit> mockCockpit = new Mock<IMyCockpit>();
+                test.MockBlocksOfType("test cockpit", mockCockpit);
+                MockShipVelocities(mockCockpit, new Vector3D(2, 3, 6), Vector3D.Zero);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Velocity is 7: True", test.Logger[0]);
             }
         }
 

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/CryoChamberBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/CryoChamberBlockTests.cs
@@ -187,11 +187,11 @@ namespace EasyCommands.Tests.ScriptTests {
             using (ScriptTest test = new ScriptTest(@"Print ""Velocity: "" + the ""test cryo chamber"" velocity")) {
                 Mock<IMyCryoChamber> mockCryoChamber = new Mock<IMyCryoChamber>();
                 test.MockBlocksOfType("test cryo chamber", mockCryoChamber);
-                mockCryoChamber.Setup(b => b.GetShipSpeed()).Returns(100);
+                MockShipVelocities(mockCryoChamber, new Vector3D(2, 3, 6), Vector3D.Zero);
 
                 test.RunUntilDone();
 
-                Assert.AreEqual("Velocity: 100", test.Logger[0]);
+                Assert.AreEqual("Velocity: 2:3:6", test.Logger[0]);
             }
         }
 

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/ParachuteBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/ParachuteBlockTests.cs
@@ -127,11 +127,11 @@ namespace EasyCommands.Tests.ScriptTests {
             using (ScriptTest test = new ScriptTest(@"Print ""Parachute Velocity: "" + the ""test parachute"" velocity")) {
                 Mock<IMyParachute> mockParachute = new Mock<IMyParachute>();
                 test.MockBlocksOfType("test parachute", mockParachute);
-                mockParachute.Setup(b => b.GetVelocity()).Returns(new Vector3D(3, 0, 0));
+                mockParachute.Setup(b => b.GetVelocity()).Returns(new Vector3D(1, 2, 3));
 
                 test.RunUntilDone();
 
-                Assert.IsTrue(test.Logger.Contains("Parachute Velocity: 3"));
+                Assert.AreEqual("Parachute Velocity: 1:2:3", test.Logger[0]);
             }
         }
 

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/RemoteControlBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/RemoteControlBlockTests.cs
@@ -436,10 +436,23 @@ set the ""test remote control"" waypoints to myWaypoints")) {
                 Mock<IMyRemoteControl> mockRemoteControl = new Mock<IMyRemoteControl>();
                 test.MockBlocksOfType("test remote control", mockRemoteControl);
                 mockRemoteControl.Setup(b => b.GetShipSpeed()).Returns(100);
+                MockShipVelocities(mockRemoteControl, new Vector3D(2, 3, 6), Vector3D.Zero);
 
                 test.RunUntilDone();
 
-                Assert.AreEqual("Velocity: 100", test.Logger[0]);
+                Assert.AreEqual("Velocity: 2:3:6", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void SetTheRemoteControlVelocity() {
+            using (ScriptTest test = new ScriptTest(@"set the ""test remote control"" speed to 50")) {
+                Mock<IMyRemoteControl> mockRemoteControl = new Mock<IMyRemoteControl>();
+                test.MockBlocksOfType("test remote control", mockRemoteControl);
+
+                test.RunUntilDone();
+
+                mockRemoteControl.VerifySet(b => b.SpeedLimit = 50f);
             }
         }
 

--- a/EasyCommands/BlockHandlers/ParachuteBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/ParachuteBlockHandlers.cs
@@ -27,7 +27,7 @@ namespace IngameScript {
                 AddPropertyHandler(Property.AUTO, TerminalBlockPropertyHandler("AutoDeploy", true));
                 AddPropertyHandler(Property.RANGE, TerminalBlockPropertyHandler("AutoDeployHeight", 500));
                 AddNumericHandler(Property.RATIO, b => 1 - b.OpenRatio);
-                AddNumericHandler(Property.VELOCITY, b => (float)b.GetVelocity().Length());
+                AddVectorHandler(Property.VELOCITY, b => b.GetVelocity());
                 AddVectorHandler(Property.STRENGTH, b => b.GetTotalGravity());
                 AddVectorHandler(Property.NATURAL_GRAVITY, b => b.GetNaturalGravity());
                 AddVectorHandler(Property.ARTIFICIAL_GRAVITY, b => b.GetArtificialGravity());

--- a/EasyCommands/BlockHandlers/ShipControllerHandlers.cs
+++ b/EasyCommands/BlockHandlers/ShipControllerHandlers.cs
@@ -73,7 +73,9 @@ namespace IngameScript {
                 AddNumericHandler(Property.WEIGHT, b => b.CalculateShipMass().TotalMass);
                 AddBooleanHandler(Property.USE, b => b.IsUnderControl);
                 AddDirectionHandlers(Property.VELOCITY, Direction.NONE,
-                    TypeHandler(NumericHandler(b => (float)b.GetShipSpeed(), (b,v) => (b as IMyRemoteControl).SpeedLimit = v), Direction.NONE),
+                    TypeHandler(ReturnTypedHandler(Return.VECTOR, 
+                        TypeHandler(VectorHandler(b => VelocityVector(b)), Return.VECTOR),
+                        TypeHandler(NumericHandler(b => (float)VelocityVector(b).Length(), (b, v) => (b as IMyRemoteControl).SpeedLimit = v), Return.NUMERIC)), Direction.NONE),
                     TypeHandler(NumericHandler(b => (float)VelocityVector(b).Y), Direction.UP),
                     TypeHandler(NumericHandler(b => (float)-VelocityVector(b).Y), Direction.DOWN),
                     TypeHandler(NumericHandler(b => (float)-VelocityVector(b).X), Direction.LEFT),

--- a/docs/EasyCommands/blockHandlers/cockpit.md
+++ b/docs/EasyCommands/blockHandlers/cockpit.md
@@ -218,13 +218,13 @@ Print "Oxygen Capacity: " + "My Cockpit" capacity
 
 ## "Velocity" Property
 * Read-only
-* Primitive Type: Numeric
+* Primitive Type: Numeric/Vector
 * Takes an optional direction attribute
 * Keywords: ```velocity, velocities, speed, speeds, rate, rates, pace, paces```
 
-Returns the current velocity of the ship, in m/s.  If no direction is specified, returns the magnitude of the ship's velocity.
+Returns the current velocity of the ship, in m/s.  If no direction is specified, returns the ship's velocity vector directly, in world coordinates.
 
-If a direction is included, then returns the velocity of the ship with respect to the given direction, with respect to the cockpit's orientation.
+If a direction is included, then returns the magnitude of the ship's velocity in the given direction, with respect to the cockpit's orientation.
 
 Supported Directions:
 * Up, Down, Left, Right, Forward, Backward

--- a/docs/EasyCommands/blockHandlers/parachute.md
+++ b/docs/EasyCommands/blockHandlers/parachute.md
@@ -125,13 +125,16 @@ Print "Open Ratio: " + "My Parachute" ratio
 
 ## "Velocity" Property
 * Read-only
-* Primitive Type: Numeric
+* Primitive Type: Vector
 * Keywords: ```velocity, velocities, speed, speeds, rate, rates```
 
-Returns the speed at which the parachute is travelling, in m/s.  Useful if you're approaching the ground in a hurry and want to set the auto deployment height appropriately.
+Returns the velocity vector, in world coordinates, at which the parachute is travelling, in m/s.  Useful if you're approaching the ground in a hurry and want to set the auto deployment height appropriately.
+
+Use the "abs" [Operation](https://spaceengineers.merlinofmines.com/EasyCommands/operations "Operations") to get the parachute's current speed.
 
 ```
-Print "Descent Speed: " + "My Parachute" speed
+Print "Descent Velocity: " + "My Parachute" velocity
+Print "Descent Speed: " + abs "My Parachute" velocity
 ```
 
 ## "Gravity" Property

--- a/docs/EasyCommands/blockHandlers/remote.md
+++ b/docs/EasyCommands/blockHandlers/remote.md
@@ -106,14 +106,14 @@ run "My Remote Control"
 ```
 
 ## "Velocity" Property
-* Primitive Type: Numeric
+* Primitive Type: Numeric/Vector
 * Takes an optional direction attribute (Read-only)
 * Keywords: ```velocity, velocities, speed, speeds, rate, rates, pace, paces```
 
 This property is the same as "Velocity" for the [Cockpit Handler](https://spaceengineers.merlinofmines.com/EasyCommands/blockHandlers/cockpit "Cockpit Handler"), but also allows you to set it
 to a numeric value, which effectively sets the speed limit for the Auto Pilot.
 
-Directions are not supported when specifying the velocity.
+Directions are not supported when setting the velocity.
 
 ```
 Print "Speed: " + "My Remote Control" speed


### PR DESCRIPTION
This commit changes parachutes, cockpits and remote controls to return a Vector for velocity instead of just it's magnitude.

This PR resolves #194 