### PR TITLE
Round Operation Improvements

### DIFF
--- a/EasyCommands.Tests/EasyCommands.Tests.csproj
+++ b/EasyCommands.Tests/EasyCommands.Tests.csproj
@@ -176,6 +176,7 @@
     <Compile Include="ScriptTests\FunctionalTests\Commands\ControlCommandTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Commands\IterationCommandTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Commands\ListenCommandTests.cs" />
+    <Compile Include="ScriptTests\FunctionalTests\Operations\RoundOperatorTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Operations\SimplePowerOperatorTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Operations\SimpleJoinTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Operations\SimpleRandomTests.cs" />

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/RoundOperatorTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/RoundOperatorTests.cs
@@ -1,0 +1,93 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+
+namespace EasyCommands.Tests.ScriptTests {
+    [TestClass]
+    public class RoundOperatorTests {
+
+        #region numbers
+        [TestMethod]
+        public void RoundNumberUniOperandBeforeValue() {
+            using (var test = new ScriptTest(@"print ""My Number: "" + round 9.81 + "" rounded""")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("My Number: 10 rounded", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void RoundNumberUniOperandAfterValue() {
+            using (var test = new ScriptTest(@"print ""My Number: "" + 9.81 rounded + "" rounded""")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("My Number: 10 rounded", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void RoundNumberBiOperand() {
+            using (var test = new ScriptTest(@"print ""My Number: "" + 3.14157 rounded to 2 + "" rounded""")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("My Number: 3.14 rounded", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void RoundNumberBiOperandWithDigits() {
+            using (var test = new ScriptTest(@"print ""My Number: "" + 3.14157 rounded to 3 digits + "" rounded""")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("My Number: 3.142 rounded", test.Logger[0]);
+            }
+        }
+        #endregion
+
+        #region vectors
+        [TestMethod]
+        public void RoundVectorUniOperandBeforeValue() {
+            using (var test = new ScriptTest(@"print ""My Number: "" + round 1.2:2.3:3.4 + "" rounded""")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("My Number: 1:2:3 rounded", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void RoundVectorUniOperandAfterValue() {
+            using (var test = new ScriptTest(@"print ""My Number: "" + 1.2:2.3:3.4 rounded + "" rounded""")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("My Number: 1:2:3 rounded", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void RoundVectorBiOperand() {
+            using (var test = new ScriptTest(@"print ""My Number: "" + 1.23:2.34:3.45 rounded to 1 + "" rounded""")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("My Number: 1.2:2.3:3.4 rounded", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void RoundVectorBiOperandWithDigits() {
+            using (var test = new ScriptTest(@"print ""My Number: "" + 1.23:2.34:3.45 rounded to 1 digit + "" rounded""")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("My Number: 1.2:2.3:3.4 rounded", test.Logger[0]);
+            }
+        }
+        #endregion
+    }
+}

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -58,7 +58,7 @@ namespace IngameScript {
 
         public void InitializeParsers() {
             //Ignored words that have no command parameters
-            AddWords(Words("the", "than", "turned", "block", "panel", "chamber", "drive", "to", "from", "then", "of", "either", "for", "in", "do", "does", "second", "seconds", "be", "being"), new IgnoreCommandParameter());
+            AddWords(Words("the", "than", "turned", "block", "panel", "chamber", "drive", "to", "from", "then", "of", "either", "for", "in", "do", "does", "second", "seconds", "be", "being", "digits", "digit"), new IgnoreCommandParameter());
 
             //Selector Related Words
             AddWords(Words("blocks", "group", "panels", "chambers", "drives"), new GroupCommandParameter());
@@ -219,7 +219,6 @@ namespace IngameScript {
             AddRightUniOperationWords(Words("arcsin", "asin"), UniOperand.ASIN);
             AddRightUniOperationWords(Words("arccos", "acos"), UniOperand.ACOS);
             AddRightUniOperationWords(Words("arctan", "atan"), UniOperand.ATAN);
-            AddRightUniOperationWords(Words("round", "rnd"), UniOperand.ROUND);
             AddRightUniOperationWords(Words("sort", "sorted"), UniOperand.SORT);
             AddRightUniOperationWords(Words("ln"), UniOperand.LN);
             AddRightUniOperationWords(Words("rand", "random", "randomize"), UniOperand.RANDOM);
@@ -252,6 +251,7 @@ namespace IngameScript {
             AddBiOperationWords(Words(".."), BiOperand.RANGE, 4);
 
             AddWords(Words("-"), new MinusCommandParameter());
+            AddWords(Words("round", "rnd", "rounded"), new RoundCommandParameter());
 
             //List Words
             AddWords(Words("["), new OpenBracketCommandParameter());

--- a/EasyCommands/CommandParsers/ProcessingEngine.cs
+++ b/EasyCommands/CommandParsers/ProcessingEngine.cs
@@ -148,6 +148,13 @@ namespace IngameScript {
                 NoValueRule(Type<MinusCommandParameter>, minus => new BiOperandCommandParameter(BiOperand.SUBTRACT, 3))
             ),
 
+            //RoundProcessor
+            new BranchingProcessor<RoundCommandParameter>(
+                NoValueRule(Type<RoundCommandParameter>, round => new BiOperandCommandParameter(BiOperand.ROUND, 1)),
+                NoValueRule(Type<RoundCommandParameter>, round => new LeftUniOperationCommandParameter(UniOperand.ROUND)),
+                NoValueRule(Type<RoundCommandParameter>, round => new UniOperationCommandParameter(UniOperand.ROUND))
+            ),
+
             //AfterUniOperationProcessor
             OneValueRule(Type<LeftUniOperationCommandParameter>, requiredLeft<VariableCommandParameter>(),
                 (p, df) => new VariableCommandParameter(new UniOperandVariable(p.value, df.value))),

--- a/EasyCommands/Commands/CommandParameters.cs
+++ b/EasyCommands/Commands/CommandParameters.cs
@@ -53,6 +53,7 @@ namespace IngameScript {
         public class ColonSeparatorParameter : SimpleCommandParameter { }
         public class TernaryConditionSeparatorParameter : SimpleCommandParameter { }
         public class MinusCommandParameter : SimpleCommandParameter { }
+        public class RoundCommandParameter : SimpleCommandParameter { }
 
         public abstract class ValueCommandParameter<T> : SimpleCommandParameter {
             public T value;

--- a/EasyCommands/Common/Operations.cs
+++ b/EasyCommands/Common/Operations.cs
@@ -115,17 +115,18 @@ namespace IngameScript {
             AddUniOperation<Vector3D>(UniOperand.ABS, a => a.Length());
             AddUniOperation<Vector3D>(UniOperand.SQRT, a => Math.Sqrt(a.Length()));
             AddUniOperation<float>(UniOperand.TICKS, a => a / 60);
+            AddUniOperation<float>(UniOperand.RANDOM, a => randomGenerator.Next((int)a));
+            AddUniOperation<float>(UniOperand.SIGN, a => Math.Sign(a));
             AddBiOperation<float, float>(BiOperand.ADD, (a, b) => a + b);
             AddBiOperation<float, float>(BiOperand.SUBTRACT, (a, b) => a - b);
             AddBiOperation<float, float>(BiOperand.MULTIPLY, (a, b) => a * b);
             AddBiOperation<float, float>(BiOperand.DIVIDE, (a, b) => a / b);
             AddBiOperation<float, float>(BiOperand.MOD, (a, b) => a % b);
             AddBiOperation<float, float>(BiOperand.EXPONENT, (a, b) => Math.Pow(a, b));
+            AddBiOperation<float, float>(BiOperand.ROUND, (a, b) => Math.Round(a, (int)b));
             AddBiOperation<Vector3D, Vector3D>(BiOperand.DOT, (a, b) => a.Dot(b));
             AddBiOperation<Color, Vector3D>(BiOperand.DOT, (a, b) => (a.ToVector3()*255).Dot(b));
             AddBiOperation<Vector3D, Vector3D>(BiOperand.EXPONENT, (a, b) => 180 * Math.Acos(a.Dot(b) / (a.Length() * b.Length())) / Math.PI);
-            AddUniOperation<float>(UniOperand.RANDOM, a => randomGenerator.Next((int)a));
-            AddUniOperation<float>(UniOperand.SIGN, a => Math.Sign(a));
 
             //String
             AddUniOperation<string>(UniOperand.REVERSE, a => new string(a.Reverse().ToArray()));
@@ -150,6 +151,7 @@ namespace IngameScript {
             AddBiOperation<Vector3D, float>(BiOperand.MULTIPLY, (a, b) => Vector3D.Multiply(a, b));
             AddBiOperation<Vector3D, float>(BiOperand.DIVIDE, (a, b) => Vector3D.Divide(a, b));
             AddBiOperation<float, Vector3D>(BiOperand.MULTIPLY, (a, b) => Vector3D.Multiply(b, a));
+            AddBiOperation<Vector3D, float>(BiOperand.ROUND, (a, b) => Vector3D.Round(a, (int)b));
 
             //Modding a vector by another vector is asking to perform vector rejection.
             //See https://en.wikipedia.org/wiki/Vector_projection

--- a/EasyCommands/Common/Types.cs
+++ b/EasyCommands/Common/Types.cs
@@ -29,7 +29,7 @@ namespace IngameScript {
         public enum Direction { UP, DOWN, LEFT, RIGHT, FORWARD, BACKWARD, CLOCKWISE, COUNTERCLOCKWISE, NONE }
         public enum ProgramState { RUNNING, STOPPED, COMPLETE, PAUSED }
         public enum Return { NUMERIC, BOOLEAN, STRING, VECTOR, COLOR, LIST, DEFAULT }
-        public enum BiOperand { ADD, SUBTRACT, MULTIPLY, DIVIDE, MOD, AND, OR, COMPARE, DOT, EXPONENT, RANGE, CAST, CONTAINS, SPLIT, JOIN };
+        public enum BiOperand { ADD, SUBTRACT, MULTIPLY, DIVIDE, MOD, AND, OR, COMPARE, DOT, EXPONENT, RANGE, CAST, CONTAINS, SPLIT, JOIN, ROUND };
         public enum UniOperand { REVERSE, ABS, SQRT, SIN, COS, TAN, ASIN, ACOS, ATAN, ROUND, KEYS, VALUES, TICKS, SORT, LN, RANDOM, SHUFFLE, SIGN};
         public enum AggregationMode {ANY, ALL, NONE }
     }

--- a/docs/EasyCommands/cheatsheet.md
+++ b/docs/EasyCommands/cheatsheet.md
@@ -8,7 +8,7 @@ It does not include [Items & Blueprints](https://spaceengineers.merlinofmines.co
 ## Ignored Keywords
 These words are (mostly) ignored when parsing your script, but feel free to use them to make your commands sound more natural.
 
-* ```the, than, turned, block, panel, chamber, drive, to, from, then, of, either, for, in, do, does, second, seconds, be, being```
+* ```the, than, turned, block, panel, chamber, drive, to, from, then, of, either, for, in, do, does, second, seconds, be, being, digit, digts```
 * ```#``` - Script Comment, when used as the first character of a line (after trimming spaces).
 
 ## Selectors
@@ -210,7 +210,7 @@ These properties require a Variable value as part of the property
 * Arctan - ```arctan, atan```
 * Sign - ```sign, quantize```
 * Random - ```random, rand```
-* Round - ```round, rnd```
+* Round - ```round, rnd, rounded```
 * Shuffle - ```shuffle, shuffled```
 * Sort - ```sort, sorted```
 * Multiply - ```multiply, *```

--- a/docs/EasyCommands/operations.md
+++ b/docs/EasyCommands/operations.md
@@ -39,11 +39,11 @@ Print "Result: " + result
 #Result: 3
 ```
 
-All UniOperand Operations are evaluated before BiOperatnd Operations.
+All UniOperand Operations are evaluated before BiOperand Operations.
 
 Here are the tiers for BiOperand Operations:
 * Tier 0 BiOperand Operations: ```.```
-* Tier 1 BiOperand Operations: ```^```
+* Tier 1 BiOperand Operations: ```^, round```
 * Tier 2 BiOperand Operations: ```*, /, %, split, join```
 * Tier 3 BiOperand Operations: ```+, -```
 * Tier 4 BiOperand Operations: ```.., cast```
@@ -91,6 +91,42 @@ print "b: " + b
 EasyCommands will do its best to infer whether you meant by "-", but may not be perfect.  If needed, use parantheses to clarify your intent.
 
 Negation resolves before subtraction, so ```-a-a``` resolves to ```(-a) - a```, vs ```-(a-a)```.
+
+## Rounding
+Rounding can be used to either quickly round number and vector values to an integer, or to round numbers and vector values to a specific number of digits.
+
+Keywords:  ```round, rnd, rounded```
+
+Note that "digit and "digits" are ignored keywords.
+
+If the digits to round to are not specified, rounding takes precedence over other BiOperands like ```*,+``` etc.  When the number of digits are specified, then Rounding acts as a tier 1 BiOperand.
+
+Here's some examples for rounding numbers:
+```
+print pi rounded to 2 digits
+#3.14
+
+print "Decimal: " + pi rounded 1
+#Decimal: 3.1
+
+print "Integer: " + 9.81 rounded
+#Integer: 10
+
+set myValue to 5.617
+print "My Value: " + round myValue
+#My Value: 6
+```
+
+And here's some examples for rounding vectors:
+```
+print "1.11:2.22:3.33" rounded to 1 digit
+#1.1:2.2:3.3
+
+print "1.11:2.22:3.33" rounded
+#1:2:3
+
+print "My Cockpit" velocity rounded to 2 digits
+```
 
 ## Uni Operations
 
@@ -198,10 +234,10 @@ set myList to ["one", "two", "three"]
 set myReversedList to reversed myList
 ```
 
-### Round
+### Round (before or after)
 Behavior varies based on input types.
 
-Keywords: ```round, rnd```
+Keywords: ```round, rnd, rounded```
 
 * **(Number)**: Rounds the given number to the nearest integer (half-up)
 * **(Vector)**: Rounds each vector component to the nearest integer (half-up)
@@ -457,6 +493,14 @@ set myList to ["one", "two", "three"]
 for each i in 0..count of myList[] - 1
   Print "myList[" + i + "]: " + myList[i]
 ```
+
+### Round
+Behavior varies based on input types.
+
+Keywords: ```round, rnd, rounded```
+
+* **(Number, Number)**: Rounds the given number a to the given number of digits, b. (half-up)
+* **(Vector, Number)**: Rounds each vector component of the given vector a to the given number of digits, b. (half-up)
 
 ### Split
 Splits the given string by the given string separator.  The result is a List containing the separated values.


### PR DESCRIPTION
This commit expands the Round operation to support an optional number of digits to round the given number to.  It also adds support for specifying the round
operation before or after the given number or vector to be rounded.

This PR resolves #179 