### PR TITLE
Changed String Primitive Parsing

### DIFF
--- a/EasyCommands.Tests/EasyCommands.Tests.csproj
+++ b/EasyCommands.Tests/EasyCommands.Tests.csproj
@@ -186,6 +186,7 @@
     <Compile Include="ScriptTests\FunctionalTests\Commands\SimpleWaitCommandTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Operations\Comparisons\SimpleComparisonsColorTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\MessageHandlingTests.cs" />
+    <Compile Include="ScriptTests\FunctionalTests\Primitives\SimpleStringTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Variables\SimpleAggregationTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Primitives\SimpleColorTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Primitives\SimpleVectorTests.cs" />

--- a/EasyCommands.Tests/ParameterParsingTests/OperatorParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/OperatorParameterProcessorTests.cs
@@ -158,7 +158,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void AssignAbsoluteValueVector() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to abs \"1:0:0\" + 2");
+            var command = program.ParseCommand("assign a to abs 1:0:0 + 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -187,7 +187,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void AssignSquareRootValueVector() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to sqrt \"9:0:0\" + 2");
+            var command = program.ParseCommand("assign a to sqrt 9:0:0 + 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -338,7 +338,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void AssignVectorNumericAddition() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to \"1:0:0\" + 2");
+            var command = program.ParseCommand("assign a to 1:0:0 + 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -350,7 +350,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void AssignVectorNumericSubtraction() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to \"1:0:0\" - 2");
+            var command = program.ParseCommand("assign a to 1:0:0 - 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -362,7 +362,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void AssignVectorNumericMultiplication() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to \"1:0:0\" * 2");
+            var command = program.ParseCommand("assign a to 1:0:0 * 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -374,7 +374,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void AssignVectorNumericDivision() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to \"2:0:0\" / 2");
+            var command = program.ParseCommand("assign a to 2:0:0 / 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -386,7 +386,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void AssignVectorMultiplication() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to \"0:1:0\" * \"1:0:0\"");
+            var command = program.ParseCommand("assign a to 0:1:0 * 1:0:0");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -398,7 +398,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void AssignVectorDotProduct() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to \"0:1:0\" . \"1:0:0\"");
+            var command = program.ParseCommand("assign a to 0:1:0 . 1:0:0");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -410,7 +410,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void AssignVectorSign() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to sign \"-0.5:1.5:0\"");
+            var command = program.ParseCommand("assign a to sign -0.5:1.5:0");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is UniOperandVariable);
@@ -458,7 +458,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void AssignVectorMod() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to \"1:1:0\" % \"0:1:0\"");
+            var command = program.ParseCommand("assign a to 1:1:0 % 0:1:0");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -506,7 +506,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void AssignVectorExponentAsAngleBetween() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to \"0:0:1\" ^ \"1:0:0\"");
+            var command = program.ParseCommand("assign a to 0:0:1 ^ 1:0:0");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Assert.IsTrue(assignment.variable is BiOperandVariable);
@@ -682,7 +682,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void AssignColor() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to \"red\"");
+            var command = program.ParseCommand("assign a to red");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Primitive primitive = assignment.variable.GetValue();
@@ -693,7 +693,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void AssignColorFromHex() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to \"#ff0000\"");
+            var command = program.ParseCommand("assign a to #ff0000");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Primitive primitive = assignment.variable.GetValue();
@@ -704,7 +704,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void AssignAddedColors() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to \"#ff0000\" + \"#00ff00\"");
+            var command = program.ParseCommand("assign a to #ff0000 + #00ff00");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Primitive primitive = assignment.variable.GetValue();
@@ -715,7 +715,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void AssignSubtractedColors() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to \"#ffff00\" - \"#00ff00\"");
+            var command = program.ParseCommand("assign a to #ffff00 - #00ff00");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Primitive primitive = assignment.variable.GetValue();
@@ -726,7 +726,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void AssignMultipliedColor() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to \"#112233\" * 2");
+            var command = program.ParseCommand("assign a to #112233 * 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Primitive primitive = assignment.variable.GetValue();
@@ -737,7 +737,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void AssignDividedColor() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to \"#224466\" / 2");
+            var command = program.ParseCommand("assign a to #224466 / 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Primitive primitive = assignment.variable.GetValue();
@@ -748,7 +748,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void AssignNotColor() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to not \"red\"");
+            var command = program.ParseCommand("assign a to not red");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
             Primitive primitive = assignment.variable.GetValue();

--- a/EasyCommands.Tests/ParameterParsingTests/SimpleVariableParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SimpleVariableParameterProcessorTests.cs
@@ -255,11 +255,10 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void ParseSimpleVector() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to \"53573.9750085028:-26601.8512032533:12058.8229348438\"");
+            var command = program.ParseCommand("assign a to 53573.9750085028:-26601.8512032533:12058.8229348438");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
-            Assert.IsTrue(assignCommand.variable is VectorVariable);
-            var variable = assignCommand.variable as VectorVariable;
+            var variable = assignCommand.variable;
             Assert.AreEqual(Return.VECTOR, variable.GetValue().returnType);
             Vector3D vector = CastVector(variable.GetValue());
             Assert.AreEqual(53573.9750085028, vector.X);
@@ -270,11 +269,10 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         [TestMethod]
         public void ParseVectorFromGPSCoordinate() {
             var program = MDKFactory.CreateProgram<Program>();
-            var command = program.ParseCommand("assign a to \"GPS:surface:53573.9750085028:-26601.8512032533:12058.8229348438:#FF75C9F1:\"");
+            var command = program.ParseCommand("assign a to \"GPS:surface:53573.9750085028:-26601.8512032533:12058.8229348438:#FF75C9F1:\" as vector");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
-            Assert.IsTrue(assignCommand.variable is VectorVariable);
-            var variable = assignCommand.variable as VectorVariable;
+            var variable = assignCommand.variable;
             Assert.AreEqual(Return.VECTOR, variable.GetValue().returnType);
             Vector3D vector = CastVector(variable.GetValue());
             Assert.AreEqual(53573.9750085028, vector.X);

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/LaserAntennaBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/LaserAntennaBlockTests.cs
@@ -47,7 +47,7 @@ namespace EasyCommands.Tests.ScriptTests {
 
         [TestMethod]
         public void SetTheLaserAntennaTargetImplicit() {
-            using (ScriptTest test = new ScriptTest(@"set the ""test laser"" to ""1:2:3""")) {
+            using (ScriptTest test = new ScriptTest(@"set the ""test laser"" to 1:2:3")) {
                 Mock<IMyLaserAntenna> mockLaserAntenna = new Mock<IMyLaserAntenna>();
                 test.MockBlocksOfType("test laser", mockLaserAntenna);
 

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/LightBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/LightBlockTests.cs
@@ -47,7 +47,7 @@ turn on the ""cool light""
         public void SetLightBlockColorFromVector() {
             String script = @"
 :lightshow
-set the ""cool light"" color to ""255:128:0""
+set the ""cool light"" color to 255:128:0
 ";
 
             using (ScriptTest test = new ScriptTest(script)) {

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/SimpleCastTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/SimpleCastTests.cs
@@ -42,10 +42,14 @@ Print -1 as bool
         public void CastStringAsBool() {
             var script = @"
 Print ""True"" as bool
-Print ""1"" as bool
+Print ""true"" as bool
 Print ""False"" as bool
+Print ""false"" as bool
+Print ""1"" as bool
 Print ""0"" as bool
+Print ""-1"" as bool
 Print ""abc"" as bool
+Print ""0:0:0"" as bool
 ";
 
             using (var test = new ScriptTest(script)) {
@@ -55,7 +59,12 @@ Print ""abc"" as bool
                 Assert.AreEqual("True", test.Logger[1]);
                 Assert.AreEqual("False", test.Logger[2]);
                 Assert.AreEqual("False", test.Logger[3]);
-                Assert.AreEqual("Exception Occurred:", test.Logger[4]);
+                Assert.AreEqual("True", test.Logger[4]);
+                Assert.AreEqual("False", test.Logger[5]);
+                Assert.AreEqual("True", test.Logger[6]);
+                Assert.AreEqual("False", test.Logger[7]);
+                Assert.AreEqual("Exception Occurred:", test.Logger[8]);
+                Assert.AreEqual("Cannot convert vector to boolean", test.Logger[9]);
             }
         }
 

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Primitives/SimpleStringTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Primitives/SimpleStringTests.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using IngameScript;
+
+namespace EasyCommands.Tests.ScriptTests {
+    [TestClass]
+    public class SimpleStringTests {
+        [TestMethod]
+        public void AmbiguousString() {
+            using (var test = new ScriptTest(@"Print ""String: "" + myString")) {
+                test.RunOnce();
+
+                Assert.AreEqual("String: myString", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AmbiguousStringInQuotes() {
+            using (var test = new ScriptTest(@"Print ""String: "" + ""myString""")) {
+                test.RunOnce();
+
+                Assert.AreEqual("String: myString", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void ExplicitStringVectorIsAString() {
+            using (var test = new ScriptTest(@"
+set a to 4
+Print ""String: "" + ""a:b:c""
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("String: a:b:c", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void ExplicitStringColorIsAString() {
+            using (var test = new ScriptTest(@"Print ""String: "" + ""red""")) {
+                test.RunOnce();
+
+                Assert.AreEqual("String: red", test.Logger[0]);
+            }
+        }
+    }
+}

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Primitives/SimpleVectorTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Primitives/SimpleVectorTests.cs
@@ -15,6 +15,15 @@ namespace EasyCommands.Tests.ScriptTests {
         }
 
         [TestMethod]
+        public void PrintVectorFromAmbiguousString() {
+            using (var test = new ScriptTest(@"Print ""Vector: "" + ""0:1:2""")) {
+                test.RunOnce();
+
+                Assert.AreEqual("Vector: 0:1:2", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
         public void GetVectorX() {
             using (var test = new ScriptTest(@"Print ""X: "" + (0:1:2).x")) {
                 test.RunOnce();

--- a/EasyCommands/BlockHandlers/GyroscopeBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/GyroscopeBlockHandlers.cs
@@ -29,7 +29,7 @@ namespace IngameScript {
 
                 var overrideHandler = DirectionalTypedHandler(Direction.NONE,
                         TypeHandler(ReturnTypedHandler(Return.VECTOR,
-                            TypeHandler(VectorHandler(b => new Vector3D(-b.Pitch * RadiansPerSecToRPM, b.Yaw * RadiansPerSecToRPM, b.Roll * RadiansPerSecToRPM), (b, v) => {
+                            TypeHandler(VectorHandler(b => Vector(-b.Pitch * RadiansPerSecToRPM, b.Yaw * RadiansPerSecToRPM, b.Roll * RadiansPerSecToRPM), (b, v) => {
                                 b.Pitch = RPMToRadiansPerSec * (float)-v.X;
                                 b.Yaw = RPMToRadiansPerSec * (float)v.Y;
                                 b.Roll = RPMToRadiansPerSec * (float)v.Z;

--- a/EasyCommands/CommandParsers/ParameterProcessors.cs
+++ b/EasyCommands/CommandParsers/ParameterProcessors.cs
@@ -105,37 +105,6 @@ namespace IngameScript {
             }
         }
 
-        public class PrimitiveProcessor<T> : ParameterProcessor<T> where T : class, PrimitiveCommandParameter {
-            public override List<Type> GetProcessedTypes() => NewList(typeof(BooleanCommandParameter), typeof(StringCommandParameter));
-
-            public override bool Process(List<CommandParameter> p, int i, out List<CommandParameter> finalParameters, List<List<CommandParameter>> branches) {
-                if (p[i] is StringCommandParameter) {
-                    p[i] = GetParameter((StringCommandParameter)p[i]);
-                } else if (p[i] is BooleanCommandParameter) {
-                    p[i] = new VariableCommandParameter(GetStaticVariable(((BooleanCommandParameter)p[i]).value));
-                } else {
-                    finalParameters = null;
-                    return false;
-                }
-                finalParameters = NewList(p[i]);
-                return true;
-            }
-
-            VariableCommandParameter GetParameter(StringCommandParameter value) {
-                Primitive primitive;
-                ParsePrimitive(value.value, out primitive);
-
-                Variable variable = new AmbiguousStringVariable(value.value);
-
-                if (primitive != null || value.isExplicit) {
-                    variable = new StaticVariable(primitive ?? ResolvePrimitive(value.value));
-                    if (variable.GetValue().returnType == Return.VECTOR)
-                        variable = new VectorVariable(variable);
-                }
-                return new VariableCommandParameter(variable);
-            }
-        }
-
         class BranchingProcessor<T> : ParameterProcessor<T> where T : class, CommandParameter {
             List<ParameterProcessor<T>> processors;
 

--- a/EasyCommands/Commands/CommandParameters.cs
+++ b/EasyCommands/Commands/CommandParameters.cs
@@ -22,7 +22,6 @@ namespace IngameScript {
         public interface CommandParameter {
             string Token { get; set; }
         }
-        public interface PrimitiveCommandParameter : CommandParameter { }
         public abstract class SimpleCommandParameter : CommandParameter {
             public string Token { get; set; }
         }
@@ -119,7 +118,7 @@ namespace IngameScript {
             }
         }
 
-        public class AmbiguousStringCommandParameter : ValueCommandParameter<String>, PrimitiveCommandParameter {
+        public class AmbiguousStringCommandParameter : ValueCommandParameter<String> {
             public List<CommandParameter> subTokens;
             public bool isImplicit;
             public AmbiguousStringCommandParameter(String value, bool impl, params CommandParameter[] SubTokens) : base(value) {
@@ -128,7 +127,7 @@ namespace IngameScript {
             }
         }
 
-        public class StringCommandParameter : ValueCommandParameter<String>, PrimitiveCommandParameter {
+        public class StringCommandParameter : ValueCommandParameter<String> {
             public bool isExplicit;
 
             public StringCommandParameter(string value, bool isExpl) : base(value) {
@@ -136,7 +135,7 @@ namespace IngameScript {
             }
         }
 
-        public class BooleanCommandParameter : ValueCommandParameter<bool>, PrimitiveCommandParameter {
+        public class BooleanCommandParameter : ValueCommandParameter<bool> {
             public BooleanCommandParameter(bool value) : base(value) {}
         }
 

--- a/EasyCommands/Common/Primitives.cs
+++ b/EasyCommands/Common/Primitives.cs
@@ -46,7 +46,10 @@ namespace IngameScript {
             KeyValuePair(typeof(bool), NewDictionary(
                 CastFunction(Return.BOOLEAN, p => p.value),
                 CastFunction(Return.NUMERIC, p => CastNumber(p) != 0),
-                CastFunction(Return.STRING, p => bool.Parse(CastString(p))),
+                CastFunction(Return.STRING, p => {
+                    Primitive primitive;
+                    return ParsePrimitive(CastString(p), out primitive) ? CastBoolean(primitive) : "true" == CastString(p).ToLower();
+                }),
                 CastFunction(Return.DEFAULT, Failure(Return.BOOLEAN))
             )),
             KeyValuePair(typeof(float), NewDictionary(
@@ -66,7 +69,7 @@ namespace IngameScript {
             KeyValuePair(typeof(Vector3D), NewDictionary(
                 CastFunction(Return.STRING, p => GetVector(CastString(p)).Value),
                 CastFunction(Return.VECTOR, p => p.value),
-                CastFunction(Return.COLOR, p => new Vector3D(CastColor(p).R, CastColor(p).G, CastColor(p).B)),
+                CastFunction(Return.COLOR, p => Vector(CastColor(p).R, CastColor(p).G, CastColor(p).B)),
                 CastFunction(Return.DEFAULT, Failure(Return.VECTOR))
             )),
             KeyValuePair(typeof(Color), NewDictionary(
@@ -117,7 +120,7 @@ namespace IngameScript {
                 double result;
                 if (Double.TryParse(component, out result)) components.Add(result);
             }
-            return components.Count() == 3 ? new Vector3D(components[0], components[1], components[2]) : (Vector3D?)null;
+            return components.Count() == 3 ? Vector(components[0], components[1], components[2]) : (Vector3D?)null;
         }
 
         static string VectorToString(Vector3D vector) => vector.X + ":" + vector.Y + ":" + vector.Z;

--- a/EasyCommands/Common/Utilities.cs
+++ b/EasyCommands/Common/Utilities.cs
@@ -22,13 +22,18 @@ namespace IngameScript {
         public const float RPMToRadiansPerSec = (float)Math.PI / 30f;
         public const float RadiansPerSecToRPM = 30f / (float)Math.PI;
 
-        static T Type<T>() => default(T);
+        public static T Type<T>() => default(T);
 
         public delegate T Supplier<T>();
 
         //Utilities for constructing collections with few characters
-        static List<T> NewList<T>(params T[] elements) => new List<T>(elements);
-        static Dictionary<T, U> NewDictionary<T, U>(params KeyValuePair<T, U>[] elements) => elements.ToDictionary(e => e.Key, e => e.Value);
-        static KeyValuePair<T, U> KeyValuePair<T, U>(T key, U value) => new KeyValuePair<T, U>(key, value);
+        public static List<T> NewList<T>(params T[] elements) => new List<T>(elements);
+        public static Dictionary<T, U> NewDictionary<T, U>(params KeyValuePair<T, U>[] elements) => elements.ToDictionary(e => e.Key, e => e.Value);
+        public static KeyValuePair<T, U> KeyValuePair<T, U>(T key, U value) => new KeyValuePair<T, U>(key, value);
+        public static Variable EmptyList() => GetStaticVariable(NewKeyedList());
+
+        //Other useful utilities
+        public static Variable GetStaticVariable(object o) => new StaticVariable(ResolvePrimitive(o));
+        public static Vector3D Vector(double x, double y, double z) => new Vector3D(x, y, z);
     }
 }

--- a/EasyCommands/Common/Variables.cs
+++ b/EasyCommands/Common/Variables.cs
@@ -23,10 +23,6 @@ namespace IngameScript {
             Primitive GetValue();
         }
 
-        public static Variable GetStaticVariable(object o) => new StaticVariable(ResolvePrimitive(o));
-        public static Variable EmptyList() => GetStaticVariable(NewKeyedList());
-        public static Variable StaticVectorVariable(double x, double y, double z) => new VectorVariable(GetStaticVariable(new Vector3D(x, y, z)));
-
         public class StaticVariable : Variable {
             public Primitive primitive;
 
@@ -56,30 +52,12 @@ namespace IngameScript {
         }
 
         public class VectorVariable : Variable {
-            public Variable vec, X, Y, Z;
-
-            public VectorVariable(Variable vector) {
-                vec = vector;
-            }
-            public VectorVariable(Variable x, Variable y, Variable z) {
-                X = x;
-                Y = y;
-                Z = z;
-            }
+            public Variable X, Y, Z;
 
             public Primitive GetValue() {
-                if (vec != null) {
-                    if (vec.GetValue().returnType == Return.VECTOR)
-                        return vec.GetValue();
-                    else
-                        throw new Exception("Invalid Vector");
-                }
-                else {
-                    if (NewList(X, Y, Z).All(v => v.GetValue().returnType == Return.NUMERIC))
-                        return ResolvePrimitive(new Vector3D(CastNumber(X.GetValue()), CastNumber(Y.GetValue()), CastNumber(Z.GetValue())));
-                    else
-                        throw new Exception("Invalid Variable in Vector");
-                }
+                if (NewList(X, Y, Z).All(v => v.GetValue().returnType == Return.NUMERIC))
+                    return ResolvePrimitive(Vector(CastNumber(X.GetValue()), CastNumber(Y.GetValue()), CastNumber(Z.GetValue())));
+                throw new Exception("Invalid Variable in Vector");
             }
         }
 

--- a/EasyCommands/Program.cs
+++ b/EasyCommands/Program.cs
@@ -66,12 +66,12 @@ namespace IngameScript {
                 KeyValuePair("pi", GetStaticVariable(Math.PI)),
                 KeyValuePair("e", GetStaticVariable(Math.E)),
                 KeyValuePair("empty", GetStaticVariable(NewKeyedList())),
-                KeyValuePair("x", StaticVectorVariable(1 ,0, 0)),
-                KeyValuePair("y", StaticVectorVariable(0, 1, 0)),
-                KeyValuePair("z", StaticVectorVariable(0, 0, 1)),
-                KeyValuePair("r", StaticVectorVariable(1 ,0, 0)),
-                KeyValuePair("g", StaticVectorVariable(0, 1, 0)),
-                KeyValuePair("b", StaticVectorVariable(0, 0, 1))
+                KeyValuePair("x", GetStaticVariable(Vector(1 ,0, 0))),
+                KeyValuePair("y", GetStaticVariable(Vector(0, 1, 0))),
+                KeyValuePair("z", GetStaticVariable(Vector(0, 0, 1))),
+                KeyValuePair("r", GetStaticVariable(Vector(1 ,0, 0))),
+                KeyValuePair("g", GetStaticVariable(Vector(0, 1, 0))),
+                KeyValuePair("b", GetStaticVariable(Vector(0, 0, 1)))
             );
         }
 

--- a/docs/EasyCommands/operations.md
+++ b/docs/EasyCommands/operations.md
@@ -333,6 +333,35 @@ set myVector to myVector as vector
 set the "Remote Control" destination to myVector
 ```
 
+### Supported Casts
+
+#### Boolean
+* Number -> Bool, returns true if != 0, false otherwise
+* String -> Bool, returns true if the string is a represents a number != 0, or if the lowercase string equals "true".  Throws an exception if the string represents a vector or color.  Returns false otherwise.
+
+#### Number
+* Bool -> Number, returns 1 if true, 0 otherwise
+* String -> Number, attempts to parse the given string as a number.  Throws a script halting exception if unable to parse.
+* Vector -> Number, returns the vector's length
+
+#### String
+* Bool -> String, returns ```True``` if true, ```False``` otherwise
+* Number -> String, returns the string version of the number
+* Vector -> String, returns the string version of the vector, in the form ```x:y:z```
+* Color -> String, returns the hex string version of the color, in the form ```#RRGGBB```
+* List -> String, prints out the list in the form ```[key1->value1,value2,key3->value3]``` (keys only included if present, order maintained)
+
+#### Vector
+* String -> Vector, attempts to parse the given String as a vector by separating values by colon and looking for 3 numeric values.  Can be used to parse vectors as well as GPS coordinates.
+* Color -> Vector, returns a vector whose x,y,z components are the r,g,b components of the color, respectively.
+
+#### Color
+* String -> Color, attempts to parse the given String as a color, using either known colors (```red```) or Hex syntax (```#FF0000```)
+* Vector -> Color, returns a Color whose r,g,b components are the x,y,z components of the vector, respectively.  Useful for creating colors directly using RGB values.
+
+#### List
+List has no supported conversion types currently
+
 ### Comparison
 
 There are a few different comparisons supported by EasyCommands.  Comparison support and behavior changes slightly based on the input types, see below for description.

--- a/docs/EasyCommands/primitives.md
+++ b/docs/EasyCommands/primitives.md
@@ -19,14 +19,55 @@ False: off, terminate, cancel, end, false, stop, stopped, halt, halted
 
 ## String
 
-String primitives allow you to specify human readable things to render on screen.  These are useful for messages and labels
+String primitives allow you to specify human readable things to render on screen.  These are useful for messages and labels.
 
 ```
 set myMessage to "This is my message"
 print "My Message is: " + myMessage
 ```
 
-String do not have to be wrapped in quotes, but best practice would be to wrap things you intend to be strings.
+String do not have to be wrapped in quotes, but best practice would be to wrap things you intend to be strings.  Any random text is considered a string if and only if it does not map to a reserved keyword, function name, or variable name and cannot be parsed as a different primitive (like a vector or a color).  EasyCommands will attempt to parse any non-quoted strings as other primitives types before considering them as a string.
+
+```
+set a to red
+print "a is: " + a
+#a is: #FF0000
+
+print "a is: " + "a"
+#a is: a
+```
+
+That said, you can cast quoted strings to other primitive types using the cast operation.
+
+Colors:
+
+```
+set myString to "red"
+print myString
+#red
+
+print myString as color
+#FF0000
+```
+
+Vectors:
+
+```
+set a to 4
+Print "Vector: " + a:b:c
+#Vector: 4:b:c
+
+Print "String: " + "a:b:c"
+#String: a:b:c
+```
+
+This is also handy for parsing GPS coordinates as vectors.
+
+```
+set myVector to "GPS:merlin waypoint:1:2:3:#FFFF0000"
+print "myVector is: " + myVector
+#myVector is: 1:2:3
+```
 
 ### Explicit Strings
 


### PR DESCRIPTION
This commit changes string parsing so that anything wrapped in double quotes is not automatically converted to primitives.  Direct values can still be used, as can
conversions from string to the requested formats.

Also removed PrimitiveProcessor which is no longer needed.