### PR TITLE
Added UniOperand Cast and Type Operand Support

### DIFF
--- a/EasyCommands.Tests/EasyCommands.Tests.csproj
+++ b/EasyCommands.Tests/EasyCommands.Tests.csproj
@@ -177,7 +177,9 @@
     <Compile Include="ScriptTests\FunctionalTests\Commands\ControlCommandTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Commands\IterationCommandTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Commands\ListenCommandTests.cs" />
+    <Compile Include="ScriptTests\FunctionalTests\Operations\Comparisons\SimpleInvalidComparisonsTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Operations\RoundOperatorTests.cs" />
+    <Compile Include="ScriptTests\FunctionalTests\Operations\SimpleTypeOperatorTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Operations\SimplePowerOperatorTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Operations\SimpleJoinTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Operations\SimpleRandomTests.cs" />

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/Comparisons/SimpleInvalidComparisonsTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/Comparisons/SimpleInvalidComparisonsTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace EasyCommands.Tests.ScriptTests {
+    [TestClass]
+    public class SimpleInvalidComparisonsTests {
+        [TestMethod]
+        public void InvalidBooleanComparisons() {
+            VerifyInvalid("true", "boolean", @"""string""", "string");
+            VerifyInvalid("true", "boolean", "123", "number");
+            VerifyInvalid("true", "boolean", "1:2:3", "vector");
+            VerifyInvalid("true", "boolean", "#FF0000", "color");
+            VerifyInvalid("true", "boolean", "[1,2,3]", "list");
+        }
+
+        [TestMethod]
+        public void InvalidNumberComparisons() {
+            VerifyInvalid("123", "number", "true", "boolean");
+            VerifyInvalid("123", "number", @"""string""", "string");
+            VerifyInvalid("123", "number", "#FF0000", "color");
+            VerifyInvalid("123", "number", "[1,2,3]", "list");
+        }
+
+        [TestMethod]
+        public void InvalidStringComparisons() {
+            VerifyInvalid("string", "string", "true", "boolean");
+            VerifyInvalid("string", "string", "123", "number");
+            VerifyInvalid("string", "string", "1:2:3", "vector");
+            VerifyInvalid("string", "string", "#FF0000", "color");
+            VerifyInvalid("string", "string", "[1,2,3]", "list");
+        }
+
+        [TestMethod]
+        public void InvalidVectorComparisons() {
+            VerifyInvalid("1:2:3", "vector", "true", "boolean");
+            VerifyInvalid("1:2:3", "vector", "string", "string");
+            VerifyInvalid("1:2:3", "vector", "#FF0000", "color");
+            VerifyInvalid("1:2:3", "vector", "[1,2,3]", "list");
+        }
+
+        [TestMethod]
+        public void InvalidColorComparisons() {
+            VerifyInvalid("#FF0000", "color", "true", "boolean");
+            VerifyInvalid("#FF0000", "color", "string", "string");
+            VerifyInvalid("#FF0000", "color", "123", "number");
+            VerifyInvalid("#FF0000", "color", "1:2:3", "vector");
+            VerifyInvalid("#FF0000", "color", "[1,2,3]", "list");
+        }
+
+        [TestMethod]
+        public void InvalidListComparisons() {
+            VerifyInvalid("([1,2,3])", "list", "true", "boolean");
+            VerifyInvalid("([1,2,3])", "list", "string", "string");
+            VerifyInvalid("([1,2,3])", "list", "123", "number");
+            VerifyInvalid("([1,2,3])", "list", "1:2:3", "vector");
+            VerifyInvalid("([1,2,3])", "list", "#FF0000", "color");
+        }
+
+        private void VerifyInvalid(string value1, string type1, string value2, string type2) {
+            using (var test = new ScriptTest("print " + value1 + " = " + value2)) {
+                test.RunOnce();
+
+                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Cannot perform operation: compare on types: " + type1 + ", " + type2, test.Logger[1]);
+            }
+
+        }
+    }
+}

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/RoundOperatorTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/RoundOperatorTests.cs
@@ -89,5 +89,40 @@ namespace EasyCommands.Tests.ScriptTests {
             }
         }
         #endregion
+
+        #region InvalidRounding
+        [TestMethod]
+        public void CannotRoundString() {
+            using (var test = new ScriptTest(@"print ""myString"" rounded")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Cannot perform operation: round on type: string", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CannotRoundStringToDigits() {
+            using (var test = new ScriptTest(@"print ""myString"" rounded to 2 digits")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Cannot perform operation: round on types: string, number", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CannotRoundNumberToStringDigits() {
+            using (var test = new ScriptTest(@"print 123 rounded to ""myString"" digits")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Cannot perform operation: round on types: number, string", test.Logger[1]);
+            }
+        }
+        #endregion
     }
 }

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/SimpleCastTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/SimpleCastTests.cs
@@ -5,6 +5,361 @@ namespace EasyCommands.Tests.ScriptTests
     [TestClass]
     public class SimpleCastTests
     {
+        #region RightUniOperand
+        [TestMethod]
+        public void CastBool() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast true
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("True", test.Logger[0]);
+                Assert.AreEqual("boolean", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastTrueStringToBool() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast ""true""
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("True", test.Logger[0]);
+                Assert.AreEqual("boolean", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastFalseStringToBool() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast ""false""
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("False", test.Logger[0]);
+                Assert.AreEqual("boolean", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastTRUEStringToBool() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast ""TRUE""
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("True", test.Logger[0]);
+                Assert.AreEqual("boolean", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastFALSEStringToBool() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast ""FALSE""
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("False", test.Logger[0]);
+                Assert.AreEqual("boolean", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastIntegerToNumber() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast 100
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("100", test.Logger[0]);
+                Assert.AreEqual("number", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastIntegerStringToNumber() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast ""100""
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("100", test.Logger[0]);
+                Assert.AreEqual("number", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastDecimalToNumber() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast 3.1415
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("3.1415", test.Logger[0]);
+                Assert.AreEqual("number", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastDecimalStringToNumber() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast ""3.1415""
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("3.1415", test.Logger[0]);
+                Assert.AreEqual("number", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastVector() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast 1:2:3
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("1:2:3", test.Logger[0]);
+                Assert.AreEqual("vector", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastVectorString() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast ""1:2:3""
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("1:2:3", test.Logger[0]);
+                Assert.AreEqual("vector", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastGPSCoordinateStringAsVector() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast ""GPS:surface:53573.9750085028:-26601.8512032533:12058.8229348438:#FF75C9F1:""
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("53573.9750085028:-26601.8512032533:12058.8229348438", test.Logger[0]);
+                Assert.AreEqual("vector", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastColor() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast red
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("#FF0000", test.Logger[0]);
+                Assert.AreEqual("color", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastColorString() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast ""red""
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("#FF0000", test.Logger[0]);
+                Assert.AreEqual("color", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastHexColor() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast #FF0000
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("#FF0000", test.Logger[0]);
+                Assert.AreEqual("color", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastHexColorString() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast ""#FF0000""
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("#FF0000", test.Logger[0]);
+                Assert.AreEqual("color", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastList() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast [1,2,3]
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("[1,2,3]", test.Logger[0]);
+                Assert.AreEqual("list", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastListStringNotSupported() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast ""[1,2,3]""
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("[1,2,3]", test.Logger[0]);
+                Assert.AreEqual("string", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastNonPrimitiveReturnOriginalString() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast unknownString
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("unknownString", test.Logger[0]);
+                Assert.AreEqual("string", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastString() {
+            using (var test = new ScriptTest(@"
+set myVariable to cast ""unknownString""
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("unknownString", test.Logger[0]);
+                Assert.AreEqual("string", test.Logger[1]);
+            }
+        }
+        #endregion
+
+        #region LeftUniOperand
+        [TestMethod]
+        public void BoolStringResolved() {
+            using (var test = new ScriptTest(@"
+set myVariable to ""true"" resolved
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("True", test.Logger[0]);
+                Assert.AreEqual("boolean", test.Logger[1]);
+            }
+
+        }
+
+        [TestMethod]
+        public void DecimalStringResolved() {
+            using (var test = new ScriptTest(@"
+set myVariable to ""3.1415"" resolved
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("3.1415", test.Logger[0]);
+                Assert.AreEqual("number", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void VectorStringResolved() {
+            using (var test = new ScriptTest(@"
+set myVariable to ""1:2:3"" resolved
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("1:2:3", test.Logger[0]);
+                Assert.AreEqual("vector", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void HexColorStringResolved() {
+            using (var test = new ScriptTest(@"
+set myVariable to ""#FF0000"" resolved
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("#FF0000", test.Logger[0]);
+                Assert.AreEqual("color", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void StringResolved() {
+            using (var test = new ScriptTest(@"
+set myVariable to ""unknownString"" resolved
+print myVariable
+print myVariable type
+")) {
+                test.RunOnce();
+
+                Assert.AreEqual("unknownString", test.Logger[0]);
+                Assert.AreEqual("string", test.Logger[1]);
+            }
+        }
+        #endregion
+
         #region Boolean
         [TestMethod]
         public void CastBoolAsBool() {
@@ -284,6 +639,17 @@ Print ""abc"" as vector
                 Assert.AreEqual("0:0:7", test.Logger[0]);
                 Assert.AreEqual("Exception Occurred:", test.Logger[1]);
 
+            }
+        }
+
+        [TestMethod]
+        public void CastGPSStringAsVector() {
+            var script = @"Print ""GPS:surface:53573.9750085028:-26601.8512032533:12058.8229348438:#FF75C9F1:"" as vector";
+
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.AreEqual("53573.9750085028:-26601.8512032533:12058.8229348438", test.Logger[0]);
             }
         }
 

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/SimpleTypeOperatorTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/SimpleTypeOperatorTests.cs
@@ -1,0 +1,150 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+
+namespace EasyCommands.Tests.ScriptTests {
+    [TestClass]
+    public class SimpleTypeOperatorTests {
+        [TestMethod]
+        public void PrintBooleanType() {
+            using (var test = new ScriptTest(@"print True type")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("boolean", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void PrintTrueVariableType() {
+            using (var test = new ScriptTest(@"
+set myVariable to False
+print myVariable type")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("boolean", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void PrintStringType() {
+            using (var test = new ScriptTest(@"print ""myString"" type")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("string", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void PrintStringVariableType() {
+            using (var test = new ScriptTest(@"
+set myVariable to ""myString""
+print myVariable type")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("string", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void PrintNumberType() {
+            using (var test = new ScriptTest(@"print 1.23 type")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("number", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void PrintNumberVariableType() {
+            using (var test = new ScriptTest(@"
+set myVariable to 1.23
+print myVariable type")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("number", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void PrintVectorType() {
+            using (var test = new ScriptTest(@"print 1:2:3 type")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("vector", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void PrintVectorVariableType() {
+            using (var test = new ScriptTest(@"
+set myVariable to 1:2:3
+print myVariable type")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("vector", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void PrintColorType() {
+            using (var test = new ScriptTest(@"print red type")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("color", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void PrintHexColorType() {
+            using (var test = new ScriptTest(@"print #FF0000 type")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("color", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void PrintColorVariableType() {
+            using (var test = new ScriptTest(@"
+set myVariable to red
+print myVariable type")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("color", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void PrintListType() {
+            using (var test = new ScriptTest(@"print [1,2,3] type")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("list", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void PrintListVariableType() {
+            using (var test = new ScriptTest(@"
+set myVariable to [1,2,3]
+print myVariable type")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("list", test.Logger[0]);
+            }
+        }
+    }
+}

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -26,8 +26,16 @@ namespace IngameScript {
         string[] secondPassTokens = new[] { "<", ">", "=", "&", "|", "-", "+", "?", ":" };
         string[] thirdPassTokens = new[] { "." };
 
-        Dictionary<UniOperand, String> uniOperandToString = NewDictionary<UniOperand, String>();
-        Dictionary<BiOperand, String> biOperandToString = NewDictionary<BiOperand, String>();
+        Dictionary<UniOperand, String> uniOperandToString = NewDictionary<UniOperand, String>(
+            KeyValuePair(UniOperand.CAST, "cast"),
+            KeyValuePair(UniOperand.ROUND, "round"),
+            KeyValuePair(UniOperand.REVERSE, "negate")
+        );
+        Dictionary<BiOperand, String> biOperandToString = NewDictionary<BiOperand, String>(
+            KeyValuePair(BiOperand.CAST, "cast"),
+            KeyValuePair(BiOperand.ROUND, "round"),
+            KeyValuePair(BiOperand.COMPARE, "compare")
+        );
         Dictionary<Return, String> returnToString = NewDictionary(
             KeyValuePair(Return.BOOLEAN, "boolean"),
             KeyValuePair(Return.NUMERIC, "number"),
@@ -39,6 +47,7 @@ namespace IngameScript {
 
         static Dictionary<string, Converter> castMap = NewDictionary(
             CastFunction("bool", p => CastBoolean(p)),
+            CastFunction("boolean", p => CastBoolean(p)),
             CastFunction("string", CastString),
             CastFunction("number", p => CastNumber(p)),
             CastFunction("vector", p => CastVector(p)),
@@ -228,6 +237,7 @@ namespace IngameScript {
             AddLeftUniOperationWords(Words("tick", "ticks"), UniOperand.TICKS);
             AddLeftUniOperationWords(Words("keys", "indexes"), UniOperand.KEYS);
             AddLeftUniOperationWords(Words("values"), UniOperand.VALUES);
+            AddLeftUniOperationWords(Words("type"), UniOperand.TYPE);
 
             //Tier 0 Operations
             AddWords(Words("dot", "."), new BiOperandCommandParameter(BiOperand.DOT, 0));
@@ -247,11 +257,11 @@ namespace IngameScript {
             AddBiOperationWords(Words("minus"), BiOperand.SUBTRACT, 3);
 
             //Tier 4 Operations
-            AddBiOperationWords(Words("as", "cast"), BiOperand.CAST, 4);
             AddBiOperationWords(Words(".."), BiOperand.RANGE, 4);
 
             AddWords(Words("-"), new MinusCommandParameter());
             AddWords(Words("round", "rnd", "rounded"), new RoundCommandParameter());
+            AddWords(Words("as", "cast", "resolve", "resolved"), new CastCommandParameter());
 
             //List Words
             AddWords(Words("["), new OpenBracketCommandParameter());
@@ -456,10 +466,12 @@ namespace IngameScript {
 
         public static bool ParsePrimitive(String token, out Primitive primitive) {
             primitive = null;
+            bool boolean;
             var vector = GetVector(token);
             Double numeric;
             var color = GetColor(token);
-            if (Double.TryParse(token, out numeric)) primitive = ResolvePrimitive((float)numeric);
+            if (bool.TryParse(token, out boolean)) primitive = ResolvePrimitive(boolean);
+            if (Double.TryParse(token, out numeric)) primitive = ResolvePrimitive(numeric);
             if (vector.HasValue) primitive = ResolvePrimitive(vector.Value);
             if (color.HasValue) primitive = ResolvePrimitive(color.Value);
             return primitive != null;

--- a/EasyCommands/CommandParsers/ProcessingEngine.cs
+++ b/EasyCommands/CommandParsers/ProcessingEngine.cs
@@ -155,6 +155,13 @@ namespace IngameScript {
                 NoValueRule(Type<RoundCommandParameter>, round => new UniOperationCommandParameter(UniOperand.ROUND))
             ),
 
+            //CastProcessor
+            new BranchingProcessor<CastCommandParameter>(
+                NoValueRule(Type<CastCommandParameter>, round => new BiOperandCommandParameter(BiOperand.CAST, 4)),
+                NoValueRule(Type<CastCommandParameter>, round => new LeftUniOperationCommandParameter(UniOperand.CAST)),
+                NoValueRule(Type<CastCommandParameter>, round => new UniOperationCommandParameter(UniOperand.CAST))
+            ),
+
             //AfterUniOperationProcessor
             OneValueRule(Type<LeftUniOperationCommandParameter>, requiredLeft<VariableCommandParameter>(),
                 (p, df) => new VariableCommandParameter(new UniOperandVariable(p.value, df.value))),

--- a/EasyCommands/Commands/CommandParameters.cs
+++ b/EasyCommands/Commands/CommandParameters.cs
@@ -53,6 +53,7 @@ namespace IngameScript {
         public class TernaryConditionSeparatorParameter : SimpleCommandParameter { }
         public class MinusCommandParameter : SimpleCommandParameter { }
         public class RoundCommandParameter : SimpleCommandParameter { }
+        public class CastCommandParameter : SimpleCommandParameter { }
 
         public abstract class ValueCommandParameter<T> : SimpleCommandParameter {
             public T value;

--- a/EasyCommands/Common/Operations.cs
+++ b/EasyCommands/Common/Operations.cs
@@ -65,6 +65,11 @@ namespace IngameScript {
         public void InitializeOperators() {
             //Object
             AddUniOperation<KeyedList>(UniOperand.RANDOM, a => a.GetValue(ResolvePrimitive(randomGenerator.Next(a.keyedValues.Count))).GetValue().value);
+            AddUniOperation<object>(UniOperand.CAST, a => a);
+            AddUniOperation<string>(UniOperand.CAST, a => {
+                Primitive output;
+                return ParsePrimitive(a, out output) ? output.value : a;
+            });
 
             //List
             AddBiOperation<KeyedList, object>(BiOperand.ADD, (a, b) => Combine(a, b));
@@ -130,6 +135,7 @@ namespace IngameScript {
 
             //String
             AddUniOperation<string>(UniOperand.REVERSE, a => new string(a.Reverse().ToArray()));
+            AddUniOperation<object>(UniOperand.TYPE, a => PROGRAM.returnToString[ResolvePrimitive(a).returnType]);
             AddBiOperation<string, object>(BiOperand.ADD, (a, b) => a + CastString(ResolvePrimitive(b)));
             AddBiOperation<object, string>(BiOperand.ADD, (a, b) => CastString(ResolvePrimitive(a)) + b);
             AddBiOperation<string, string>(BiOperand.SUBTRACT, (a, b) => a.Contains(b) ? a.Remove(a.IndexOf(b)) + a.Substring(a.IndexOf(b) + b.Length) :  a);

--- a/EasyCommands/Common/Primitives.cs
+++ b/EasyCommands/Common/Primitives.cs
@@ -48,7 +48,7 @@ namespace IngameScript {
                 CastFunction(Return.NUMERIC, p => CastNumber(p) != 0),
                 CastFunction(Return.STRING, p => {
                     Primitive primitive;
-                    return ParsePrimitive(CastString(p), out primitive) ? CastBoolean(primitive) : "true" == CastString(p).ToLower();
+                    return ParsePrimitive(CastString(p), out primitive) ? CastBoolean(primitive) : false;
                 }),
                 CastFunction(Return.DEFAULT, Failure(Return.BOOLEAN))
             )),

--- a/EasyCommands/Common/Types.cs
+++ b/EasyCommands/Common/Types.cs
@@ -30,7 +30,7 @@ namespace IngameScript {
         public enum ProgramState { RUNNING, STOPPED, COMPLETE, PAUSED }
         public enum Return { NUMERIC, BOOLEAN, STRING, VECTOR, COLOR, LIST, DEFAULT }
         public enum BiOperand { ADD, SUBTRACT, MULTIPLY, DIVIDE, MOD, AND, OR, COMPARE, DOT, EXPONENT, RANGE, CAST, CONTAINS, SPLIT, JOIN, ROUND };
-        public enum UniOperand { REVERSE, ABS, SQRT, SIN, COS, TAN, ASIN, ACOS, ATAN, ROUND, KEYS, VALUES, TICKS, SORT, LN, RANDOM, SHUFFLE, SIGN};
+        public enum UniOperand { REVERSE, ABS, SQRT, SIN, COS, TAN, ASIN, ACOS, ATAN, ROUND, KEYS, VALUES, TICKS, SORT, LN, RANDOM, SHUFFLE, SIGN, CAST, TYPE};
         public enum AggregationMode {ANY, ALL, NONE }
     }
 }

--- a/docs/EasyCommands/operations.md
+++ b/docs/EasyCommands/operations.md
@@ -69,7 +69,37 @@ Print "Result: " + result
 #Result: 8
 ```
 
-### The Minus Sign
+## Casting Variables To Other Types
+Sometimes you may want to convert one input type to another, for example, a string input which is actually supposed to be a number.  You can do this using the Cast Operation.
+
+Keywords:  ```cast, as, resolve, resolved```
+
+The Cast operation can be used as either a UniOperand or as BiOperand.
+
+### Casting As a UniOperand
+
+When used as a UniOperand, the Cast operand will attempt to parse a given string variable as another variable type, by looking at its structure.  Here are some Examples:
+
+```
+set myBool to cast "true"
+set myNumber to cast "3.14"
+set myVector to cast "1:2:3"
+set myColor to cast "red"
+set myColor to cast "#FF0000"
+set myString to cast "Some random String"
+```
+
+Casting strings to lists is not currently supported.  If the input variable is not a string, it is returned without any conversion.  So casting a vector does nothing.
+
+See the Cast under UniOperands for more information.
+
+### Casting as a BiOperand
+
+When used as a BiOperand, the Cast Operation expects the second variable to be a string representing one of the supported cast types.
+
+See Cast under BiOperands below for more information.
+
+## The Minus Sign
 ```-``` can be used as either a UniOperand to negate a value (See the Not Operation)), or as a BiOperand to subtract a value from another value (see the Subtraction operation).
 
 ```
@@ -138,14 +168,6 @@ Keywords: ```abs, absolute```
 * **(Number)**: Absolute value of the number
 * **(Vector)**: Returns the length of the vector
 
-### Sign
-Behavior varies based on input type.
-
-Keywords: ```sign, quantize```
-
-* **(Number)**: Return the sign of the number or 0
-* **(Vector)**: Returns the vector with the sign of each component or 0
-
 ### Arc Cosine
 Performs the arc cosine operation on the given numeric value
 
@@ -160,6 +182,29 @@ Keywords: ```asin, arcsin```
 Performs the arc tan operation on the given numeric value
 
 Keywords: ```atan, arctan```
+
+### Cast (Before or After)
+Casts the given string variable to another variable type by attempting to resolve it to the appropriate type.
+
+Keywords: ```cast, resolve, resolved```
+
+```
+#number
+set myVariable to cast "123.4"
+
+#Vector
+set myVariable to "1:2:3" resolved
+
+#Color
+set myVariable to resolve "#FF0000"
+```
+
+If the input type is not a string, will return the original value.  If the input string cannot be parsed as a supported Primitive Type, the original string will be returned.
+
+```
+#Returns the original string
+set myVariable to resolve "Some Random String"
+```
 
 ### Cosine
 Performs the cosine operation on the given numeric value
@@ -247,6 +292,14 @@ Shuffles the given list.  This does not modify the input list but rather returns
 
 Keywords: ```shuffle, shuffled```
 
+### Sign
+Behavior varies based on input type.
+
+Keywords: ```sign, quantize```
+
+* **(Number)**: Return the sign of the number or 0
+* **(Vector)**: Returns the vector with the sign of each component or 0
+
 ### Sin
 Performs the sin operation on the given numeric value
 
@@ -286,6 +339,63 @@ wait 30 ticks
 #Wait 30 seconds
 wait 30
 ```
+
+### Type (After)
+Returns the [Primitive Type](https://spaceengineers.merlinofmines.com/EasyCommands/primitives "Primitives") of the given variable as a string.
+
+Keywords: ```type```
+
+Possible output values: ```boolean, string, number, vector, color, list```
+
+```
+set myVariable to "True"
+print myVariable type
+#bool
+
+#Notice the quotes
+set myVariable to "123"
+print myVariable type
+#string
+
+set myVariable to 123
+print myVariable type
+#number
+
+set myVariable to 1:2:3
+print myVariable type
+#vector
+
+set myVariable to #FF0000
+print myVariable type
+#color
+
+set myVariable to [1,2,3]
+print myVariable type
+#list
+```
+
+This is particularly useful when trying to cast arbitrary input as a value.
+
+```
+#Pretend the text is "1"
+set myInput to "My Display" text
+
+#This will resolve the input string to a primitive type but you don't know which
+set myResolvedVariable to resolve myInput
+
+#This will tell you what type you are dealing with
+set myVariableType to myResolvedVariable type
+print "Type: " + myVariableType
+#number
+
+if myVariableType is number
+  set myNewValue to myResolvedVariable + 10
+  print myNewValue
+  #11
+else
+  set "My Display" text to "Input must be a number! Try again"
+```
+
 ### Values (After)
 Gets the values from the given list (ignoring keys).  The list is expected to come before the operand.
 
@@ -325,12 +435,27 @@ This special operation allows you to cast a given value as another value.  This 
 
 Keywords: ```cast, as```
 
-Cast Types: ```bool, string, number, vector, color, list```
+Cast Types: ```bool, boolean, string, number, vector, color, list```
 
 ```
 set myVector to 1 + ":" + 2 + ":" + 3
 set myVector to myVector as vector
 set the "Remote Control" destination to myVector
+```
+
+If you attempt to cast a variable to a type that it cannot be converted to, you will get a script halting exception.  So before casting to a specific type make sure you know you can cast it to that type.
+
+If you are unsure of the type, use the "Cast" UniOperand to cast it to whatever type it actually is, and then check its type using the Type operation before converting.
+
+```
+#Pretend I don't know what this value is
+set myInputValue to "My Display" text
+
+set myResolvedValue to cast myInputValue
+if myResolvedValue type is not number
+  Print "Input Value must be a number!"
+else
+  Print "Input Number is: " + myResolvedValue
 ```
 
 ### Supported Casts

--- a/docs/EasyCommands/primitives.md
+++ b/docs/EasyCommands/primitives.md
@@ -4,6 +4,8 @@ Primitive Types in EasyCommands represent the different kinds of [Variables](htt
 
 See [Operations](https://spaceengineers.merlinofmines.com/EasyCommands/operations "Operations") for a list of all the operations that you can perform on the various primitive types.
 
+You can also convert some primitive types to other primitive types using the Cast Operation.  See [Casting Primitives](https://spaceengineers.merlinofmines.com/EasyCommands/operations "Operations") for more information.
+
 ## Boolean
 The most basic primitive type is boolean, which can either be true or false.  Booleans are used when evaluating conditions and setting true/false like "Enabled".
 ```
@@ -53,19 +55,15 @@ print myString as color
 Vectors:
 
 ```
-set a to 4
-Print "Vector: " + a:b:c
-#Vector: 4:b:c
-
-Print "String: " + "a:b:c"
-#String: a:b:c
+Print "Vector: " + "1:2:3" as vector
+#Vector: 1:2:3
 ```
 
 This is also handy for parsing GPS coordinates as vectors.
 
 ```
 set myVector to "GPS:merlin waypoint:1:2:3:#FFFF0000"
-print "myVector is: " + myVector
+print "myVector is: " + myVector as vector
 #myVector is: 1:2:3
 ```
 
@@ -139,10 +137,10 @@ Internally numbers are stored using floating point precision (as is most of Easy
 
 ## Vectors
 
-Vectors represent 3D coordinates and are used for a variety of purposes, such as for positions, directions, target locations, detected entity locations, and some other interesting properties.  They take the form "x:y:z" where x,y,z represent the x,y,z coordinates, respectively.
+Vectors represent 3D coordinates and are used for a variety of purposes, such as for positions, directions, target locations, detected entity locations, and some other interesting properties.  They take the form ```x:y:z``` where x,y,z represent the x,y,z coordinates, respectively.
 
 ```
-set myCoords to "4:5:6"
+set myCoords to 4:5:6
 set the "Remote Control" waypoint to myCoords
 set myPosition to my position
 ```
@@ -160,7 +158,7 @@ Print "Z: " + myVector.z
 
 ### Creating Vectors Using Variables
 
-You can create vectors using [Variables](https://spaceengineers.merlinofmines.com/EasyCommands/variables "Variables") using the syntax "a:b:c" where a,b,c are the names of variables.  Note that you must use "a:b:c" format.  "a : b : c" will not work.
+You can create vectors using [Variables](https://spaceengineers.merlinofmines.com/EasyCommands/variables "Variables") using the syntax "a:b:c" where a,b,c are the names of variables.  Note that you must use ```a:b:c``` format.  ```a : b : c``` will not work.
 
 Similar rules for setting or binding variables applies to Variable Vectors.  Setting a variable to a variable vector will set a static vector based on the values of the variables at the time it was created.  Binding a variable to a variable vector will effectively create a vector with dynamic values.
 
@@ -186,9 +184,19 @@ print "My Dynamic Vector: " + myDynamicVector
 #4:2:3
 ```
 
+### Creating Vectors from GPS coordinates
+
+Vectors can be parsed from GPS coordinates by using the GPS coordinate as a String (wrapped in quotes) and then casting to a vector.
+
+```
+set myVector to "GPS:surface:53573.9750085028:-26601.8512032533:12058.8229348438:#FF75C9F1:" as vector
+print myVector
+#53573.9750085028:-26601.8512032533:12058.8229348438
+```
+
 ## Colors
 
-There are some blocks types that support colors, such as text colors on screen.  You can create colors using special reserved keywords, or by explicitly declaring hex values.
+There are some blocks types that support colors, such as text colors on screen.  You can create colors using special reserved keywords, or by explicitly declaring hex values, or using casting a vector representing R:G:B.
 
 ```
 #All of these are the equivalent color


### PR DESCRIPTION
This PR updates the cast operation to act as either a UniOperand or a BiOperand.  As a UniOperand it will attempt to parse a string as the appropriate primitive
without needing to specify the expected type.  This is useful for parsing ambiguous input without causing script halting exceptions.

This commit also implements the Type operation, which enables you to get the type of a variable.  This is also useful for inspecting resolved input to verify it is
the correct type before attempting to use it as the type you are expecting.

This commit also fixes a previous bug where invalid cast and round operations were not logged correctly.

This commit also updates some incorrect documentation around vectors and adds documentation around parsing GPS coordinates.