### PR TITLE
Attempt at Consolidating Property Support

### DIFF
--- a/EasyCommands.Tests/ParameterParsingTests/AggregateBlockPropertyProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/AggregateBlockPropertyProcessorTests.cs
@@ -100,8 +100,8 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
             AggregatePropertyVariable aggregate = (AggregatePropertyVariable)assignCommand.variable;
             VerifyAggregator(aggregate.aggregator, 6f); //Sum
-            Assert.AreEqual(ValueProperty.AMOUNT + "", aggregate.property.propertyType);
-            Assert.AreEqual("gold ingot", aggregate.property.attributeValue.GetValue().value);
+            Assert.AreEqual(Property.AMOUNT + "", aggregate.property.properties[0].propertyType);
+            Assert.AreEqual("gold ingot", aggregate.property.properties[0].attributeValue.GetValue().value);
         }
 
         [TestMethod]
@@ -198,7 +198,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             Assert.IsTrue(assignCommand.variable is AggregatePropertyVariable);
             AggregatePropertyVariable aggregate = (AggregatePropertyVariable)assignCommand.variable;
             VerifyAggregator(aggregate.aggregator, 6f); //Sum
-            Assert.AreEqual(Property.POSITION + "", aggregate.property.propertyType);
+            Assert.AreEqual(Property.POSITION + "", aggregate.property.properties[0].propertyType);
             Assert.IsTrue(aggregate.entityProvider is SelfSelector);
             Assert.AreEqual(Block.PROGRAM, aggregate.entityProvider.GetBlockType());
         }

--- a/EasyCommands/BlockHandlers/AirVentBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/AirVentBlockHandlers.cs
@@ -27,7 +27,6 @@ namespace IngameScript {
                 AddNumericHandler(Property.RATIO, b => b.GetOxygenLevel());
                 AddNumericHandler(Property.LEVEL, b => b.GetOxygenLevel());
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.RATIO;
-                defaultPropertiesByDirection[Direction.UP] = Property.RATIO;
             }
 
             bool InProgress(IMyAirVent b) => (b.Status == VentStatus.Depressurizing || b.Status == VentStatus.Pressurizing) && b.GetOxygenLevel() > 0.0001;

--- a/EasyCommands/BlockHandlers/AntennaBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/AntennaBlockHandlers.cs
@@ -38,7 +38,6 @@ namespace IngameScript {
                 AddBooleanHandler(Property.SHOW, b => b.ShowShipName, (b, v) => b.ShowShipName = v);
                 defaultPropertiesByPrimitive[Return.STRING] = Property.TEXT;
                 defaultPropertiesByPrimitive[Return.BOOLEAN] = Property.CONNECTED;
-                defaultPropertiesByDirection[Direction.UP] = Property.RANGE;
             }
         }
     }

--- a/EasyCommands/BlockHandlers/AssemblerBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/AssemblerBlockHandlers.cs
@@ -24,19 +24,19 @@ namespace IngameScript {
                 AddBooleanHandler(Property.SUPPLY, b => b.Mode == MyAssemblerMode.Assembly, (b, v) => b.Mode = v ? MyAssemblerMode.Assembly : MyAssemblerMode.Disassembly);
                 AddBooleanHandler(Property.COMPLETE, b => b.IsQueueEmpty, (b,v) => { if (!v) b.ClearQueue(); });
                 AddBooleanHandler(Property.AUTO, b => b.CooperativeMode, (b, v) => b.CooperativeMode = v);
-                AddPropertyHandler(ValueProperty.CREATE, new PropertyHandler<IMyAssembler>() {
-                    Get = (b, p) => ResolvePrimitive(b.Mode == MyAssemblerMode.Assembly && GetProducingAmount(b, p) >= GetRequestedAmount(p)),
+                AddPropertyHandler(new PropertyHandler<IMyAssembler>() {
+                    Get = (b, p) => ResolvePrimitive(b.Mode == MyAssemblerMode.Assembly && GetProducingAmount(b, p) >= GetRequestedAttributeOrPropertyValue(p, 1)),
                     Set = (b, p, v) => { b.Mode = MyAssemblerMode.Assembly; AddQueueItem(b, p); }
-                }) ;
-                AddPropertyHandler(ValueProperty.DESTROY, new PropertyHandler<IMyAssembler>() {
-                    Get = (b, p) => ResolvePrimitive(b.Mode == MyAssemblerMode.Disassembly && GetProducingAmount(b, p) >= GetRequestedAmount(p)),
+                }, Property.CREATE);
+                AddPropertyHandler(new PropertyHandler<IMyAssembler>() {
+                    Get = (b, p) => ResolvePrimitive(b.Mode == MyAssemblerMode.Disassembly && GetProducingAmount(b, p) >= GetRequestedAttributeOrPropertyValue(p, 1)),
                     Set = (b, p, v) => { b.Mode = MyAssemblerMode.Disassembly; AddQueueItem(b, p); }
-                });
+                }, Property.DESTROY);
 
-                AddPropertyHandler(ValueProperty.AMOUNT, new PropertyHandler<IMyAssembler>() {
+                AddPropertyHandler(new PropertyHandler<IMyAssembler>() {
                     Get = (b, v) => ResolvePrimitive(GetProducingAmount(b, v)),
                     Set = (b, p, v) => AddQueueItem(b, p)
-                });
+                }, Property.AMOUNT);
 
                 AddListHandler(Property.TYPES, b => {
                     var currentItems = NewList<MyProductionItem>();
@@ -45,11 +45,16 @@ namespace IngameScript {
                 });
             }
 
-            float GetRequestedAmount(PropertySupplier p) => CastNumber(NewList(p.attributeValue.GetValue(), (p.propertyValue ?? GetStaticVariable(1)).GetValue()).Find(v => v.returnType == Return.NUMERIC) ?? ResolvePrimitive(1));
-            string GetRequestedItemFilter(PropertySupplier p) => CastString(NewList(p.attributeValue.GetValue(), (p.propertyValue ?? GetStaticVariable("*")).GetValue()).Find(v => v.returnType == Return.STRING) ?? ResolvePrimitive("*"));
-
+            //Returns the value of first attribute or property variable with the same return type as default value,
+            //otherwise the default value. Attributes are checked first.
+            T GetRequestedAttributeOrPropertyValue<T>(PropertySupplier supplier, T defaultValue) =>
+                (T)supplier.properties.Where(p => p.attributeValue != null)
+                    .Select(p => p.attributeValue.GetValue())
+                        .Concat(NewList(supplier.propertyValue?.GetValue() ?? ResolvePrimitive(defaultValue)))
+                    .First(v => v.returnType == ResolvePrimitive(defaultValue).returnType).value;
+                
             float GetProducingAmount(IMyAssembler b, PropertySupplier p) {
-                var definitions = PROGRAM.GetItemBluePrints(GetRequestedItemFilter(p));
+                var definitions = PROGRAM.GetItemBluePrints(GetRequestedAttributeOrPropertyValue(p, "*"));
                 var currentItems = NewList<MyProductionItem>();
                 b.GetQueue(currentItems);
                 MyFixedPoint value = currentItems
@@ -61,8 +66,8 @@ namespace IngameScript {
             }
 
             void AddQueueItem(IMyAssembler b, PropertySupplier p) {
-                float amount = GetRequestedAmount(p);
-                foreach(MyDefinitionId bp in PROGRAM.GetItemBluePrints(GetRequestedItemFilter(p))) {
+                float amount = GetRequestedAttributeOrPropertyValue(p, 1);
+                foreach(MyDefinitionId bp in PROGRAM.GetItemBluePrints(GetRequestedAttributeOrPropertyValue(p, "*"))) {
                     try { b.AddQueueItem(bp, (MyFixedPoint)amount); } catch (Exception) {
                         throw new Exception("Unknown BlueprintId: " + bp.SubtypeId);
                     }

--- a/EasyCommands/BlockHandlers/BatteryBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/BatteryBlockHandlers.cs
@@ -29,7 +29,6 @@ namespace IngameScript {
                 AddNumericHandler(Property.VOLUME, b => b.CurrentOutput);
                 AddNumericHandler(Property.LEVEL, b => b.CurrentStoredPower);
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.RATIO;
-                defaultPropertiesByDirection[Direction.UP] = Property.RATIO;
              }
         }
     }

--- a/EasyCommands/BlockHandlers/BeaconBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/BeaconBlockHandlers.cs
@@ -26,7 +26,6 @@ namespace IngameScript {
                 AddBooleanHandler(Property.SUPPLY, b => b.Enabled, (b, v) => b.Enabled = v);
                 defaultPropertiesByPrimitive[Return.STRING] = Property.TEXT;
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.RANGE;
-                defaultPropertiesByDirection[Direction.UP] = Property.RANGE;
             }
         }
     }

--- a/EasyCommands/BlockHandlers/CameraBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/CameraBlockHandlers.cs
@@ -21,27 +21,30 @@ namespace IngameScript {
     partial class Program {
         public class CameraBlockHandler : FunctionalBlockHandler<IMyCameraBlock> {
             public CameraBlockHandler() {
-                AddBooleanHandler(Property.TRIGGER, (b) => CastVector(GetPropertyValue(b, new PropertySupplier(Property.TARGET+""))) != Vector3D.Zero, (b, v) => b.EnableRaycast = v);
+                AddBooleanHandler(Property.TRIGGER, b => GetTarget(b) != Vector3D.Zero, (b, v) => b.EnableRaycast = v);
                 AddNumericHandler(Property.RANGE, GetRange, (b, v) => SetCustomProperty(b, "Range", "" + v), 100);
                 AddVectorHandler(Property.TARGET_VELOCITY, (b) => GetVector(GetCustomProperty(b, "Velocity")).GetValueOrDefault());
                 //TODO: Use setter to scan specific vector?
-                AddVectorHandler(Property.TARGET, (b) => {
-                    var range = (double)GetRange(b);
-                    b.EnableRaycast = true;
-                    if (b.CanScan(range)) {
-                        MyDetectedEntityInfo detectedEntity = b.Raycast(range);
-                        if (!detectedEntity.IsEmpty()) {
-                            SetCustomProperty(b, "Target", VectorToString(GetPosition(detectedEntity)));
-                            SetCustomProperty(b, "Velocity", VectorToString(detectedEntity.Velocity));
-                        } else {
-                            DeleteCustomProperty(b, "Target");
-                        }
-                    }
-                    return GetVector(GetCustomProperty(b, "Target") ?? "").GetValueOrDefault();
-                });
+                AddVectorHandler(Property.TARGET, GetTarget);
                 defaultPropertiesByPrimitive[Return.VECTOR] = Property.TARGET;
-                defaultPropertiesByDirection[Direction.UP] = Property.RANGE;
+                defaultPropertiesByPrimitive[Return.NUMERIC] = Property.RANGE;
             }
+
+            public Vector3D GetTarget(IMyCameraBlock b) {
+                var range = (double)GetRange(b);
+                b.EnableRaycast = true;
+                if (b.CanScan(range)) {
+                    MyDetectedEntityInfo detectedEntity = b.Raycast(range);
+                    if (!detectedEntity.IsEmpty()) {
+                        SetCustomProperty(b, "Target", VectorToString(GetPosition(detectedEntity)));
+                        SetCustomProperty(b, "Velocity", VectorToString(detectedEntity.Velocity));
+                    } else {
+                        DeleteCustomProperty(b, "Target");
+                    }
+                }
+                return GetVector(GetCustomProperty(b, "Target") ?? "").GetValueOrDefault();
+            }
+
             public float GetRange(IMyCameraBlock b) => float.Parse(GetCustomProperty(b, "Range") ?? "1000");
         }
     }

--- a/EasyCommands/BlockHandlers/CargoBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/CargoBlockHandlers.cs
@@ -21,7 +21,7 @@ namespace IngameScript {
     partial class Program {
         public class CargoHandler : MultiInstanceBlockHandler<IMyInventory> {
             public CargoHandler() {
-                AddPropertyHandler(ValueProperty.AMOUNT, amountHandler);
+                AddPropertyHandler(amountHandler, Property.AMOUNT);
                 AddNumericHandler(Property.RATIO, i => (float)(i.CurrentVolume.RawValue / (double)i.MaxVolume.RawValue));
                 AddNumericHandler(Property.RANGE, i => (float)i.MaxVolume * 1000); //Volumes are returned in kL, convert to L
                 AddNumericHandler(Property.VOLUME, i => (float)i.CurrentVolume * 1000); //Volumes are returned in kL, convert to L
@@ -44,7 +44,7 @@ namespace IngameScript {
 
             PropertyHandler<IMyInventory> amountHandler = new PropertyHandler<IMyInventory> {
                 Get = (b, p) => {
-                    var itemString = CastString(p.attributeValue.GetValue());
+                    var itemString = CastString(p.properties[0].attributeValue.GetValue());
                     var filter = PROGRAM.AnyItem(PROGRAM.GetItemFilters(itemString));
                     double totalAmount = 0;
                     var items = NewList<MyInventoryItem>();

--- a/EasyCommands/BlockHandlers/DoorHandlers.cs
+++ b/EasyCommands/BlockHandlers/DoorHandlers.cs
@@ -24,7 +24,6 @@ namespace IngameScript {
                 AddBooleanHandler(Property.OPEN, (b) => b.Status != DoorStatus.Closed, (b, v) => { if (v) b.OpenDoor(); else b.CloseDoor(); });
                 AddNumericHandler(Property.RATIO, b => b.OpenRatio);
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.RATIO;
-                defaultPropertiesByDirection[Direction.UP] = Property.RATIO;
             }
         }
     }

--- a/EasyCommands/BlockHandlers/GasTankBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/GasTankBlockHandlers.cs
@@ -27,7 +27,6 @@ namespace IngameScript {
                 AddNumericHandler(Property.RATIO, b => (float)b.FilledRatio);
                 AddNumericHandler(Property.LEVEL, b => (float)(b.FilledRatio * b.Capacity));
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.RATIO;
-                defaultPropertiesByDirection.Add(Direction.UP, Property.RATIO);
             }
         }
     }

--- a/EasyCommands/BlockHandlers/GravityGeneratorBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/GravityGeneratorBlockHandlers.cs
@@ -22,10 +22,9 @@ namespace IngameScript {
         public class SphericalGravityGeneratorBlockHandler : FunctionalBlockHandler<IMyGravityGeneratorSphere> {
             public SphericalGravityGeneratorBlockHandler() {
                 var rangeHandler = NumericHandler(b => b.Radius, (b, v) => b.Radius = v, 25);
-                AddPropertyHandler(Property.RANGE, rangeHandler);
-                AddPropertyHandler(Property.LEVEL, rangeHandler);
+                AddPropertyHandler(rangeHandler, Property.RANGE);
+                AddPropertyHandler(rangeHandler, Property.LEVEL);
                 AddNumericHandler(Property.STRENGTH, b => b.GravityAcceleration, (b,v) => b.GravityAcceleration = v, 0.25f);
-
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.STRENGTH;
             }
         }

--- a/EasyCommands/BlockHandlers/GunBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/GunBlockHandlers.cs
@@ -52,10 +52,9 @@ namespace IngameScript {
 
         public class GunBlockHandler<T> : FunctionalBlockHandler<T> where T : class, IMyUserControllableGun {
             public GunBlockHandler() {
-                AddPropertyHandler(Property.RANGE, TerminalPropertyHandler("Range", 100));
+                AddPropertyHandler(TerminalPropertyHandler("Range", 100), Property.RANGE);
                 AddBooleanHandler(Property.TRIGGER, (b) => b.IsShooting, Shoot);
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.RANGE;
-                defaultPropertiesByDirection[Direction.UP] = Property.RANGE;
             }
             void Shoot(IMyUserControllableGun gun, bool b) =>
                 PROGRAM.actionCache.GetOrCreate(gun.GetType(), b ? "Shoot_On" : "Shoot_Off", s => gun.GetActionWithName(s)).Apply(gun);

--- a/EasyCommands/BlockHandlers/GyroscopeBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/GyroscopeBlockHandlers.cs
@@ -22,8 +22,8 @@ namespace IngameScript {
         public class GyroscopeBlockHandler<T> : FunctionalBlockHandler<T> where T : class, IMyGyro {
             public GyroscopeBlockHandler() {
                 var powerHandler = NumericHandler(b => b.GyroPower, (b, v) => b.GyroPower = v, 0.1f);
-                AddPropertyHandler(Property.RANGE, powerHandler);
-                AddPropertyHandler(Property.POWER, powerHandler);
+                AddPropertyHandler(powerHandler, Property.RANGE);
+                AddPropertyHandler(powerHandler, Property.POWER);
 
                 AddBooleanHandler(Property.AUTO, b => !b.GyroOverride, (b, v) => b.GyroOverride = !v);
 

--- a/EasyCommands/BlockHandlers/HeatVentBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/HeatVentBlockHandlers.cs
@@ -21,17 +21,17 @@ namespace IngameScript {
     partial class Program {
         public class HeatVentBlockHandler : FunctionalBlockHandler<IMyHeatVent> {
             public HeatVentBlockHandler() {
-                AddDirectionHandlers(Property.COLOR, Direction.UP,
-                    TypeHandler(TerminalPropertyHandler("ColorMax", Color.Black), Direction.UP),
-                    TypeHandler(TerminalPropertyHandler("ColorMin", Color.Black), Direction.DOWN));
-                AddPropertyHandler(Property.RANGE, TerminalPropertyHandler("Radius", 1));
-                AddPropertyHandler(Property.VOLUME, TerminalPropertyHandler("Intensity", 1));
-                AddPropertyHandler(Property.FALLOFF, TerminalPropertyHandler("Falloff", 0.3));
-                AddPropertyHandler(Property.OFFSET, TerminalPropertyHandler("Offset", 0.5));
-                AddPropertyHandler(Property.RATIO, TerminalPropertyHandler("PowerDependency", 10));
+                var maxColorHandler = TerminalPropertyHandler("ColorMax", Color.Black);
+                AddPropertyHandler(maxColorHandler, Property.COLOR);
+                AddPropertyHandler(maxColorHandler, Property.COLOR, Property.UP);
+                AddPropertyHandler(TerminalPropertyHandler("ColorMin", Color.Black), Property.COLOR, Property.DOWN);
+                AddPropertyHandler(TerminalPropertyHandler("Radius", 1), Property.RANGE);
+                AddPropertyHandler(TerminalPropertyHandler("Intensity", 1), Property.VOLUME);
+                AddPropertyHandler(TerminalPropertyHandler("Falloff", 0.3), Property.FALLOFF);
+                AddPropertyHandler(TerminalPropertyHandler("Offset", 0.5), Property.OFFSET);
+                AddPropertyHandler(TerminalPropertyHandler("PowerDependency", 10), Property.RATIO);
                 defaultPropertiesByPrimitive[Return.COLOR] = Property.COLOR;
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.RATIO;
-                defaultPropertiesByDirection[Direction.UP] = Property.COLOR;
             }
         }
     }

--- a/EasyCommands/BlockHandlers/JumpDriveBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/JumpDriveBlockHandlers.cs
@@ -26,13 +26,17 @@ namespace IngameScript {
                 AddBooleanHandler(Property.COMPLETE, b => b.Status == MyJumpDriveStatus.Ready);
                 AddBooleanHandler(Property.SUPPLY, b => !b.Recharge, (b, v) => b.Recharge = !v);
 
-                var jumpDistanceHandler = DirectionalTypedHandler(Direction.NONE,
-                    TypeHandler(NumericHandler(b => b.JumpDistanceMeters, (b,v) => b.SetValueFloat("JumpDistance", 100 * (v - b.MinJumpDistanceMeters) / (b.MaxJumpDistanceMeters - b.MinJumpDistanceMeters))), Direction.NONE),
-                    TypeHandler(NumericHandler(b => b.MaxJumpDistanceMeters), Direction.UP),
-                    TypeHandler(NumericHandler(b => b.MinJumpDistanceMeters), Direction.DOWN));
+                var jumpDistanceHandler = NumericHandler(b => b.JumpDistanceMeters, (b, v) => b.SetValueFloat("JumpDistance", 100 * (v - b.MinJumpDistanceMeters) / (b.MaxJumpDistanceMeters - b.MinJumpDistanceMeters)));
+                AddPropertyHandler(jumpDistanceHandler, Property.RANGE);
+                AddPropertyHandler(jumpDistanceHandler, Property.LEVEL);
 
-                AddPropertyHandler(Property.LEVEL, jumpDistanceHandler);
-                AddPropertyHandler(Property.RANGE, jumpDistanceHandler);
+                var maxJumpDistanceHandler = NumericHandler(b => b.MaxJumpDistanceMeters);
+                AddPropertyHandler(maxJumpDistanceHandler, Property.RANGE, Property.UP);
+                AddPropertyHandler(maxJumpDistanceHandler, Property.LEVEL, Property.UP);
+
+                var minJumpDistanceHandler = NumericHandler(b => b.MaxJumpDistanceMeters);
+                AddPropertyHandler(minJumpDistanceHandler, Property.RANGE, Property.DOWN);
+                AddPropertyHandler(minJumpDistanceHandler, Property.LEVEL, Property.DOWN);
             }
         }
     }

--- a/EasyCommands/BlockHandlers/LandingGearHandlers.cs
+++ b/EasyCommands/BlockHandlers/LandingGearHandlers.cs
@@ -23,8 +23,8 @@ namespace IngameScript {
             public LandingGearHandler() {
                 AddBooleanHandler(Property.AUTO, b => b.AutoLock, (b, v) => b.AutoLock = v);
                 var lockHandler = BooleanHandler(b => b.IsLocked, (b, v) => { if (v) b.Lock(); else b.Unlock(); });
-                AddPropertyHandler(Property.LOCKED, lockHandler);
-                AddPropertyHandler(Property.CONNECTED, lockHandler);
+                AddPropertyHandler(lockHandler, Property.LOCKED);
+                AddPropertyHandler(lockHandler, Property.CONNECTED);
             }
         }
     }

--- a/EasyCommands/BlockHandlers/LightBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/LightBlockHandlers.cs
@@ -30,7 +30,6 @@ namespace IngameScript {
                 AddNumericHandler(Property.FALLOFF, (b) => b.Falloff, (b, v) => b.Falloff = v, 0.5f);
                 defaultPropertiesByPrimitive[Return.COLOR] = Property.COLOR;
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.RANGE;
-                defaultPropertiesByDirection.Add(Direction.UP, Property.RANGE);
             }
         }
     }

--- a/EasyCommands/BlockHandlers/MergeBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/MergeBlockHandlers.cs
@@ -22,8 +22,8 @@ namespace IngameScript {
         public class MergeBlockHandler : FunctionalBlockHandler<IMyShipMergeBlock> {
             public MergeBlockHandler() : base() {
                 var connectHandler = BooleanHandler(b => b.IsConnected, (b, v) => b.Enabled = v);
-                AddPropertyHandler(Property.LOCKED, connectHandler);
-                AddPropertyHandler(Property.CONNECTED, connectHandler);
+                AddPropertyHandler(connectHandler, Property.LOCKED);
+                AddPropertyHandler(connectHandler, Property.CONNECTED);
             }
         }
     }

--- a/EasyCommands/BlockHandlers/OreDetectorHandlers.cs
+++ b/EasyCommands/BlockHandlers/OreDetectorHandlers.cs
@@ -21,10 +21,9 @@ namespace IngameScript {
     partial class Program {
         public class OreDetectorHandler : FunctionalBlockHandler<IMyOreDetector> {
             public OreDetectorHandler() {
-                AddPropertyHandler(Property.RANGE, TerminalPropertyHandler("Range", 50));
+                AddPropertyHandler(TerminalPropertyHandler("Range", 50), Property.RANGE);
                 AddBooleanHandler(Property.SUPPLY, b => b.BroadcastUsingAntennas, (b, v) => b.BroadcastUsingAntennas = v);
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.RANGE;
-                defaultPropertiesByDirection.Add(Direction.UP, Property.RANGE);
             }
         }
     }

--- a/EasyCommands/BlockHandlers/ParachuteBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/ParachuteBlockHandlers.cs
@@ -22,10 +22,10 @@ namespace IngameScript {
         public class ParachuteBlockHandler : FunctionalBlockHandler<IMyParachute> {
             public ParachuteBlockHandler() {
                 var openHandler = BooleanHandler(b => b.Status != DoorStatus.Closed, (b, v) => { if (v) b.OpenDoor(); else b.CloseDoor(); });
-                AddPropertyHandler(Property.OPEN, openHandler);
-                AddPropertyHandler(Property.TRIGGER, openHandler);
-                AddPropertyHandler(Property.AUTO, TerminalPropertyHandler("AutoDeploy", true));
-                AddPropertyHandler(Property.RANGE, TerminalPropertyHandler("AutoDeployHeight", 500));
+                AddPropertyHandler(openHandler, Property.OPEN);
+                AddPropertyHandler(openHandler, Property.TRIGGER);
+                AddPropertyHandler(TerminalPropertyHandler("AutoDeploy", true), Property.AUTO);
+                AddPropertyHandler(TerminalPropertyHandler("AutoDeployHeight", 500), Property.RANGE);
                 AddNumericHandler(Property.RATIO, b => 1 - b.OpenRatio);
                 AddVectorHandler(Property.VELOCITY, b => b.GetVelocity());
                 AddVectorHandler(Property.STRENGTH, b => b.GetTotalGravity());
@@ -36,7 +36,6 @@ namespace IngameScript {
                     return (float)(b.TryGetClosestPoint(out closestPoint) ? (closestPoint.Value - b.GetPosition()).Length() : -1);
                 });
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.LEVEL;
-                defaultPropertiesByDirection.Add(Direction.UP, Property.RATIO);
             }
         }
     }

--- a/EasyCommands/BlockHandlers/PistonBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/PistonBlockHandlers.cs
@@ -21,15 +21,32 @@ namespace IngameScript {
     partial class Program {
         public class PistonBlockHandler : FunctionalBlockHandler<IMyPistonBase> {
             public PistonBlockHandler() : base() {
-                AddDirectionHandlers(Property.RANGE, Direction.UP,
-                    TypeHandler(NumericHandler(b => b.MaxLimit, (b, v) => b.MaxLimit = v, 1), Direction.UP, Direction.FORWARD),
-                    TypeHandler(NumericHandler(b => b.MinLimit, (b, v) => b.MinLimit = v, 1), Direction.DOWN, Direction.BACKWARD));
+                var maxLimitHandler = NumericHandler(b => b.MaxLimit, (b, v) => b.MaxLimit = v, 1);
+                AddPropertyHandler(maxLimitHandler, Property.RANGE);
+                AddPropertyHandler(maxLimitHandler, Property.RANGE, Property.UP);
+                AddPropertyHandler(NumericHandler(b => b.MinLimit, (b, v) => b.MinLimit = v, 1), Property.RANGE, Property.DOWN);
+                
+                var reverseHandler = BooleanHandler(b => b.Velocity < 0, (b, v) => { if (v) b.Reverse(); });
+                AddPropertyHandler(reverseHandler, Property.REVERSE);
+                AddPropertyHandler(reverseHandler, Property.LEVEL, Property.REVERSE);
+
+                var heightHandler = NumericHandler(b => b.CurrentPosition, ExtendPistonToValue, 1);
+                AddPropertyHandler(heightHandler, Property.LEVEL);
+                AddReturnHandlers(Property.UP, Return.BOOLEAN,
+                    TypeHandler(BooleanHandler(b => b.Velocity > 0, (b, v) => b.Velocity = v ? Math.Abs(b.Velocity) : 0), Return.BOOLEAN),
+                    TypeHandler(heightHandler, Return.NUMERIC));
+                AddReturnHandlers(Property.DOWN, Return.BOOLEAN,
+                    TypeHandler(BooleanHandler(b => b.Velocity < 0, (b, v) => b.Velocity = v ? Math.Abs(b.Velocity) : 0), Return.BOOLEAN),
+                    TypeHandler(heightHandler, Return.NUMERIC));
+
+                AddBooleanHandler(Property.UP, );
+                AddBooleanHandler(Property.DOWN, b => b.Velocity < 0, (b, v) => b.Velocity = v ? -Math.Abs(b.Velocity) : 0);
+
                 AddPropertyHandler(Property.LEVEL, new PistonHeightHandler());
+
                 AddNumericHandler(Property.VELOCITY, (b) => b.Velocity, (b,v) => b.Velocity = v,1);
                 AddBooleanHandler(Property.CONNECTED, b => b.IsAttached, (b, v) => { if (v) b.Attach(); else b.Detach(); });
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.LEVEL;
-                defaultPropertiesByDirection[Direction.UP] = Property.LEVEL;
-                defaultPropertiesByDirection[Direction.DOWN] = Property.LEVEL;
             }
         }
 

--- a/EasyCommands/BlockHandlers/ProjectorBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/ProjectorBlockHandlers.cs
@@ -24,26 +24,36 @@ namespace IngameScript {
                 AddBooleanHandler(Property.COMPLETE, b => b.RemainingBlocks == 0);
                 AddNumericHandler(Property.RATIO, b => 1 - b.RemainingBlocks / (float)b.TotalBlocks);
                 AddBooleanHandler(Property.SHOW, b => b.IsProjecting, (b, v) => b.ShowOnlyBuildable = !v);
-                AddPropertyHandler(Property.LOCKED, TerminalPropertyHandler("KeepProjection", ""));
-                AddPropertyHandler(Property.LEVEL, TerminalPropertyHandler("Scale", 0.1f));
+                AddPropertyHandler(TerminalPropertyHandler("KeepProjection", ""), Property.LOCKED);
+                AddPropertyHandler(TerminalPropertyHandler("Scale", 0.1f), Property.LEVEL);
 
-                AddDirectionHandlers(Property.ROLL_INPUT, Direction.NONE,
-                    TypeHandler(VectorHandler(b => GetRotation(b), (b, v) => b.ProjectionRotation = Vector(Clamp(v.X), Clamp(v.Y), Clamp(v.Z))), Direction.NONE),
-                    TypeHandler(NumericHandler(b => GetRotation(b).X, (b, v) => SetRotation(b, Vector(0, 1, 1), Vector(v, 0, 0))), Direction.UP),
-                    TypeHandler(NumericHandler(b => -GetRotation(b).X, (b, v) => SetRotation(b, Vector(0, 1, 1), Vector(-v, 0, 0))), Direction.DOWN),
-                    TypeHandler(NumericHandler(b => GetRotation(b).Y, (b, v) => SetRotation(b, Vector(1, 0, 1), Vector(0, v, 0))), Direction.RIGHT),
-                    TypeHandler(NumericHandler(b => -GetRotation(b).Y, (b, v) => SetRotation(b, Vector(1, 0, 1), Vector(0, -v, 0))), Direction.LEFT),
-                    TypeHandler(NumericHandler(b => GetRotation(b).Z, (b, v) => SetRotation(b, Vector(1, 1, 0), Vector(0, 0, v))), Direction.CLOCKWISE),
-                    TypeHandler(NumericHandler(b => -GetRotation(b).Z, (b, v) => SetRotation(b, Vector(1, 1, 0), Vector(0, 0, -v))), Direction.COUNTERCLOCKWISE));
+                AddVectorHandler(Property.ROLL_INPUT, b => GetRotation(b), (b, v) => b.ProjectionRotation = Vector(Clamp(v.X), Clamp(v.Y), Clamp(v.Z)));
+                AddPropertyHandler(NumericHandler(b => GetRotation(b).X, (b, v) => SetRotation(b, Vector(0, 1, 1), Vector(v, 0, 0))),
+                    Property.ROLL_INPUT, Property.UP);
+                AddPropertyHandler(NumericHandler(b => -GetRotation(b).X, (b, v) => SetRotation(b, Vector(0, 1, 1), Vector(-v, 0, 0))),
+                    Property.ROLL_INPUT, Property.DOWN);
+                AddPropertyHandler(NumericHandler(b => GetRotation(b).Y, (b, v) => SetRotation(b, Vector(1, 0, 1), Vector(0, v, 0))),
+                    Property.ROLL_INPUT, Property.RIGHT);
+                AddPropertyHandler(NumericHandler(b => -GetRotation(b).Y, (b, v) => SetRotation(b, Vector(1, 0, 1), Vector(0, -v, 0))),
+                    Property.ROLL_INPUT, Property.LEFT);
+                AddPropertyHandler(NumericHandler(b => GetRotation(b).Z, (b, v) => SetRotation(b, Vector(1, 1, 0), Vector(0, 0, v))),
+                    Property.ROLL_INPUT, Property.CLOCKWISE);
+                AddPropertyHandler(NumericHandler(b => -GetRotation(b).Z, (b, v) => SetRotation(b, Vector(1, 1, 0), Vector(0, 0, -v))),
+                    Property.ROLL_INPUT, Property.COUNTERCLOCKWISE);
 
-                AddDirectionHandlers(Property.OFFSET, Direction.NONE,
-                    TypeHandler(VectorHandler(b => GetOffset(b), (b,v) => b.ProjectionOffset = new Vector3I(v)), Direction.NONE),
-                    TypeHandler(NumericHandler(b => GetOffset(b).X, (b, v) => SetOffset(b, Vector(0, 1, 1),  Vector(v, 0, 0))), Direction.RIGHT),
-                    TypeHandler(NumericHandler(b => -GetOffset(b).X, (b,v) => SetOffset(b, Vector(0, 1, 1), Vector(-v, 0, 0))), Direction.LEFT),
-                    TypeHandler(NumericHandler(b => GetOffset(b).Y, (b, v) => SetOffset(b, Vector(1, 0, 1), Vector(0, v, 0))), Direction.UP),
-                    TypeHandler(NumericHandler(b => -GetOffset(b).Y, (b, v) => SetOffset(b, Vector(1, 0, 1), Vector(0, -v, 0))), Direction.DOWN),
-                    TypeHandler(NumericHandler(b => GetOffset(b).Z, (b, v) => SetOffset(b, Vector(1, 1, 0), Vector(0, 0, v))), Direction.FORWARD),
-                    TypeHandler(NumericHandler(b => -GetOffset(b).Z, (b, v) => SetOffset(b, Vector(1, 1, 0),  Vector(0, 0, -v))), Direction.BACKWARD));
+                AddVectorHandler(Property.OFFSET, b => GetOffset(b), (b, v) => b.ProjectionOffset = new Vector3I(v));
+                AddPropertyHandler(NumericHandler(b => GetOffset(b).X, (b, v) => SetOffset(b, Vector(0, 1, 1), Vector(v, 0, 0))),
+                    Property.OFFSET, Property.RIGHT);
+                AddPropertyHandler(NumericHandler(b => -GetOffset(b).X, (b, v) => SetOffset(b, Vector(0, 1, 1), Vector(-v, 0, 0))),
+                    Property.OFFSET, Property.LEFT);
+                AddPropertyHandler(NumericHandler(b => GetOffset(b).Y, (b, v) => SetOffset(b, Vector(1, 0, 1), Vector(0, v, 0))),
+                    Property.OFFSET, Property.UP);
+                AddPropertyHandler(NumericHandler(b => -GetOffset(b).Y, (b, v) => SetOffset(b, Vector(1, 0, 1), Vector(0, -v, 0))),
+                    Property.OFFSET, Property.DOWN);
+                AddPropertyHandler(NumericHandler(b => GetOffset(b).Z, (b, v) => SetOffset(b, Vector(1, 1, 0), Vector(0, 0, v))),
+                    Property.OFFSET, Property.FORWARD);
+                AddPropertyHandler(NumericHandler(b => -GetOffset(b).Z, (b, v) => SetOffset(b, Vector(1, 1, 0), Vector(0, 0, -v))),
+                    Property.OFFSET, Property.BACKWARD);
             }
 
             void SetRotation(IMyProjector projector, Vector3I clearVector, Vector3I newOffset) => projector.ProjectionRotation = GetRotation(projector) * clearVector + new Vector3I(Clamp(newOffset.X), Clamp(newOffset.Y), Clamp(newOffset.Z));

--- a/EasyCommands/BlockHandlers/SoundBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/SoundBlockHandlers.cs
@@ -24,9 +24,9 @@ namespace IngameScript {
                 AddNumericHandler(Property.VOLUME, b => b.Volume, (b, v) => b.Volume = v, 0.1f);
                 AddNumericHandler(Property.RANGE, b => b.Range, (b, v) => b.Range = v, 50);
                 AddNumericHandler(Property.LEVEL, b => b.LoopPeriod, (b, v) => b.LoopPeriod = v, 10);
-                AddPropertyHandler(Property.MEDIA, ReturnTypedHandler(Return.STRING,
+                AddPropertyHandler(ReturnTypedHandler(Return.STRING,
                     TypeHandler(BooleanHandler((b) => b.DetailedInfo.Contains("Loop timer"), (b, v) => { if (v) b.Play(); else b.Stop(); }), Return.BOOLEAN),
-                    TypeHandler(StringHandler(b => b.SelectedSound, (b, v) => b.SelectedSound = v), Return.STRING)));
+                    TypeHandler(StringHandler(b => b.SelectedSound, (b, v) => b.SelectedSound = v), Return.STRING)), Property.MEDIA);
 
                 AddListHandler(Property.MEDIA_LIST, b => {
                     var availableSounds = NewList<string>();

--- a/EasyCommands/BlockHandlers/TextSurfaceHandlers.cs
+++ b/EasyCommands/BlockHandlers/TextSurfaceHandlers.cs
@@ -38,8 +38,8 @@ namespace IngameScript {
                 }, SetImages);
                 AddStringHandler(Property.POSITION, b => (b.Alignment + "").ToLower(), (b, v) => b.Alignment = v == "center" ? TextAlignment.CENTER : v == "right" ? TextAlignment.RIGHT : TextAlignment.LEFT);
                 AddNumericHandler(Property.INTERVAL, b => b.ChangeInterval, (b, v) => b.ChangeInterval = v, 1);
-                AddPropertyHandler(Property.LEVEL, fontSizeHandler);
-                AddPropertyHandler(Property.COLOR, fontColorHandler);
+                AddPropertyHandler(fontSizeHandler, Property.LEVEL);
+                AddPropertyHandler(fontColorHandler, Property.COLOR);
                 AddColorHandler(Property.BACKGROUND, b => b.ContentType == ContentType.SCRIPT ? b.ScriptBackgroundColor : b.BackgroundColor, (b, v) => { if (b.ContentType == ContentType.SCRIPT) b.ScriptBackgroundColor = v; else b.BackgroundColor = v; });
                 AddReturnHandlers(Property.FONT, Return.STRING,
                     TypeHandler(StringHandler(b => b.Font, (b,v) => b.Font = v), Return.STRING),
@@ -51,7 +51,6 @@ namespace IngameScript {
                 defaultPropertiesByPrimitive[Return.COLOR] = Property.COLOR;
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.LEVEL;
                 defaultPropertiesByPrimitive[Return.LIST] = Property.MEDIA_LIST;
-                defaultPropertiesByDirection[Direction.UP] = Property.TEXT;
             }
 
             void SetImages(IMyTextSurface block, KeyedList images) {

--- a/EasyCommands/BlockHandlers/ThrusterBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/ThrusterBlockHandlers.cs
@@ -22,12 +22,11 @@ namespace IngameScript {
         public class ThrusterBlockHandler : FunctionalBlockHandler<IMyThrust> {
             public ThrusterBlockHandler() {
                 var currentThrustHandler = NumericHandler(b => b.CurrentThrust, (b, v) => b.ThrustOverride = v, 5000);
-                AddPropertyHandler(Property.LEVEL, currentThrustHandler);
-                AddPropertyHandler(Property.VOLUME, currentThrustHandler);
+                AddPropertyHandler(currentThrustHandler, Property.LEVEL);
+                AddPropertyHandler(currentThrustHandler, Property.VOLUME);
                 AddNumericHandler(Property.RANGE, b => b.MaxThrust, (b, v) => b.ThrustOverride = v, 5000);
                 AddNumericHandler(Property.RATIO, b => b.ThrustOverridePercentage, (b, v) => b.ThrustOverridePercentage = v, 0.1f);
                 AddNumericHandler(Property.OVERRIDE, b => b.ThrustOverride, (b, v) => b.ThrustOverride = v, 5000);
-                defaultPropertiesByDirection[Direction.UP] = Property.RANGE;
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.LEVEL;
             }
         }

--- a/EasyCommands/BlockHandlers/WheelBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/WheelBlockHandlers.cs
@@ -25,17 +25,21 @@ namespace IngameScript {
                 AddNumericHandler(Property.ANGLE, b => (float)(-b.SteerAngle*180/Math.PI), (b, v) => { b.SteeringOverride = (float)(v * Math.PI / 144); b.MaxSteerAngle = 1; }, .1f);
                 AddBooleanHandler(Property.LOCKED, b => b.Brake, (b, v) => b.Brake = v);
                 AddBooleanHandler(Property.CONNECTED, b => b.IsAttached, (b, v) => { if (v) b.Attach(); else b.Detach(); });
-                AddDirectionHandlers(Property.RANGE, Direction.UP,
-                    TypeHandler(TerminalPropertyHandler("Speed Limit", 5), Direction.UP, Direction.DOWN),
-                    TypeHandler(NumericHandler(b => b.MaxSteerAngle, (b, v) => b.MaxSteerAngle = v), Direction.LEFT, Direction.RIGHT));
+
+                var speedLimitHandler = TerminalPropertyHandler("Speed Limit", 5);
+                AddPropertyHandler(speedLimitHandler, Property.RANGE);
+                AddPropertyHandler(speedLimitHandler, Property.RANGE, Property.UP);
+                AddPropertyHandler(speedLimitHandler, Property.RANGE, Property.DOWN);
+
+                var angleLimitHandler = NumericHandler(b => b.MaxSteerAngle, (b, v) => b.MaxSteerAngle = v);
+                AddPropertyHandler(angleLimitHandler, Property.RANGE, Property.LEFT);
+                AddPropertyHandler(angleLimitHandler, Property.RANGE, Property.RIGHT);
 
                 AddNumericHandler(Property.VELOCITY, b => b.PropulsionOverride, (b,v) => b.PropulsionOverride = v, 0.1f);
                 AddNumericHandler(Property.STRENGTH, b => b.Strength, (b, v) => b.Strength = v, 10);
                 AddNumericHandler(Property.POWER, b => b.Power, (b, v) => b.Power = v, 10);
                 AddNumericHandler(Property.RATIO, b => b.Friction, (b, v) => b.Friction = v, 10);
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.LEVEL;
-                defaultPropertiesByDirection[Direction.UP] = Property.LEVEL;
-                defaultPropertiesByDirection[Direction.DOWN] = Property.LEVEL;
             }
         }
     }

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -75,21 +75,21 @@ namespace IngameScript {
             AddWords(Words("$"), new VariableSelectorCommandParameter());
 
             //Direction Words
-            AddDirectionWords(Words("up", "upward", "upwards", "upper"), Direction.UP);
-            AddDirectionWords(Words("down", "downward", "downwards", "lower"), Direction.DOWN);
-            AddDirectionWords(Words("left", "lefthand"), Direction.LEFT);
-            AddDirectionWords(Words("right", "righthand"), Direction.RIGHT);
-            AddDirectionWords(Words("forward", "forwards", "front"), Direction.FORWARD);
-            AddDirectionWords(Words("backward", "backwards", "back"), Direction.BACKWARD);
-            AddDirectionWords(Words("clockwise", "clock"), Direction.CLOCKWISE);
-            AddDirectionWords(Words("counterclockwise", "counter", "counterclock"), Direction.COUNTERCLOCKWISE);
+            AddPropertyWords(Words("up", "upward", "upwards", "upper"), Property.UP);
+            AddPropertyWords(Words("down", "downward", "downwards", "lower"), Property.DOWN);
+            AddPropertyWords(Words("left", "lefthand"), Property.LEFT);
+            AddPropertyWords(Words("right", "righthand"), Property.RIGHT);
+            AddPropertyWords(Words("forward", "forwards", "front"), Property.FORWARD);
+            AddPropertyWords(Words("backward", "backwards", "back"), Property.BACKWARD);
+            AddPropertyWords(Words("clockwise", "clock"), Property.CLOCKWISE);
+            AddPropertyWords(Words("counterclockwise", "counter", "counterclock"), Property.COUNTERCLOCKWISE);
 
             //Action Words
             AddWords(Words("bind", "tie", "link"), new AssignmentCommandParameter(true));
             AddWords(Words("move", "go", "tell", "turn", "rotate", "set", "assign", "allocate", "designate", "apply"), new AssignmentCommandParameter());
             AddWords(Words("reverse", "reversed"), new ReverseCommandParameter());
-            AddWords(Words("raise", "extend"), new AssignmentCommandParameter(), new DirectionCommandParameter(Direction.UP));
-            AddWords(Words("retract"), new AssignmentCommandParameter(), new DirectionCommandParameter(Direction.DOWN));
+            AddWords(Words("raise", "extend"), new AssignmentCommandParameter(), new PropertyCommandParameter(Property.UP));
+            AddWords(Words("retract"), new AssignmentCommandParameter(), new PropertyCommandParameter(Property.DOWN));
             AddWords(Words("increase", "increment"), new IncreaseCommandParameter());
             AddWords(Words("decrease", "decrement", "reduce"), new IncreaseCommandParameter(false));
             AddWords(Words("++", "+="), new IncrementCommandParameter());
@@ -97,9 +97,9 @@ namespace IngameScript {
             AddWords(Words("global"), new GlobalCommandParameter());
             AddWords(Words("by"), new RelativeCommandParameter());
 
-            //Value Words
-            AddWords(Words("on", "begin", "true", "start", "started", "resume", "resumed"), new BooleanCommandParameter(true));
-            AddWords(Words("off", "terminate", "cancel", "end", "false", "stopped", "halt", "halted"), new BooleanCommandParameter(false));
+            //Boolean Words
+            AddWords(Words("on", "begin", "true", "start", "started", "resume", "resumed"), new VariableCommandParameter(GetStaticVariable(true)));
+            AddWords(Words("off", "terminate", "cancel", "end", "false", "stopped", "halt", "halted"), new VariableCommandParameter(GetStaticVariable(false)));
 
             //Property Words
             AddPropertyWords(AllWords(PluralWords("height", "length", "level", "size", "period", "scale")), Property.LEVEL);
@@ -162,11 +162,11 @@ namespace IngameScript {
             AddPropertyWords(Words("info", "details", "detailedinfo"), Property.INFO);
 
             //ValueProperty Words
-            AddWords(PluralWords("amount"), new ValuePropertyCommandParameter(ValueProperty.AMOUNT));
-            AddWords(Words("property", "attribute"), new ValuePropertyCommandParameter(ValueProperty.PROPERTY));
-            AddWords(Words("action"), new ValuePropertyCommandParameter(ValueProperty.ACTION));
-            AddWords(Words("produce", "producing", "create", "creating", "build", "building", "make", "making"), new ValuePropertyCommandParameter(ValueProperty.CREATE));
-            AddWords(Words("destroy", "destroying", "recycle", "recycling"), new ValuePropertyCommandParameter(ValueProperty.DESTROY));
+            AddWords(PluralWords("amount"), new AttributePropertyCommandParameter(Property.AMOUNT));
+            AddWords(Words("property", "attribute"), new AttributePropertyCommandParameter(Property.PROPERTY));
+            AddWords(Words("action"), new AttributePropertyCommandParameter(Property.ACTION));
+            AddWords(Words("produce", "producing", "create", "creating", "build", "building", "make", "making"), new AttributePropertyCommandParameter(Property.CREATE));
+            AddWords(Words("destroy", "destroying", "recycle", "recycling"), new AttributePropertyCommandParameter(Property.DESTROY));
 
             //Special Command Words
             AddWords(Words("times", "iterations"), new RepeatCommandParameter());
@@ -371,12 +371,8 @@ namespace IngameScript {
         }
 
         void AddPropertyWords(String[] words, Property property, bool nonNegative = true) {
-            if (!nonNegative) AddWords(words, new PropertyCommandParameter(property), new BooleanCommandParameter(false));
+            if (!nonNegative) AddWords(words, new PropertyCommandParameter(property), new PropertyCommandParameter(Property.REVERSE));
             else AddWords(words, new PropertyCommandParameter(property));
-        }
-
-        void AddDirectionWords(String[] words, Direction direction) {
-            AddWords(words, new DirectionCommandParameter(direction));
         }
 
         void AddRightUniOperationWords(String[] words, UniOperand operand) {

--- a/EasyCommands/Commands/CommandParameters.cs
+++ b/EasyCommands/Commands/CommandParameters.cs
@@ -144,20 +144,16 @@ namespace IngameScript {
             public BooleanCommandParameter(bool value) : base(value) {}
         }
 
-        public class DirectionCommandParameter : ValueCommandParameter<Direction> {
-            public DirectionCommandParameter(Direction value) : base(value) {}
-        }
-
-        public class ValuePropertyCommandParameter : ValueCommandParameter<ValueProperty> {
-            public ValuePropertyCommandParameter(ValueProperty value) : base(value) {}
+        public class AttributePropertyCommandParameter : ValueCommandParameter<Property> {
+            public AttributePropertyCommandParameter(Property value) : base(value) {}
         }
 
         public class PropertyCommandParameter : ValueCommandParameter<Property> {
             public PropertyCommandParameter(Property value) : base(value) { }
         }
 
-        public class PropertySupplierCommandParameter : ValueCommandParameter<PropertySupplier> {
-            public PropertySupplierCommandParameter(PropertySupplier value) : base(value) {}
+        public class PropertyValueCommandParameter : ValueCommandParameter<PropertyValue> {
+            public PropertyValueCommandParameter(PropertyValue value) : base(value) {}
         }
 
         public class ListCommandParameter : ValueCommandParameter<Variable> {

--- a/EasyCommands/Common/Types.cs
+++ b/EasyCommands/Common/Types.cs
@@ -24,9 +24,75 @@ namespace IngameScript {
         #endregion
 
         public enum Block { PISTON, ROTOR, PROGRAM, TIMER, LIGHT, PROJECTOR, MERGE, CONNECTOR, WELDER, GRINDER, DOOR, DISPLAY, SOUND, CAMERA, SENSOR, BEACON, ANTENNA, COCKPIT, CRYO_CHAMBER, REMOTE, THRUSTER, AIRVENT, GUN, GENERATOR, TANK, MAGNET, BATTERY, PARACHUTE, SUSPENSION, DETECTOR, DRILL, ENGINE, SORTER, TURRET, GYROSCOPE, GRAVITY_GENERATOR, GRAVITY_SPHERE, CARGO, WARHEAD, ASSEMBLER, EJECTOR, COLLECTOR, DECOY, HINGE, JUMPDRIVE, LASER_ANTENNA, TERMINAL, REFINERY, REACTOR, TURBINE, SOLAR_PANEL, HEAT_VENT }
-        public enum Property { ENABLE, POWER, CONNECTED, LOCKED, COMPLETE, OPEN, TRIGGER, SUPPLY, AUTO, OVERRIDE, LEVEL, ANGLE, VELOCITY, RATIO, FONT, VOLUME, RANGE, INPUT, ROLL_INPUT, NAME, RUN, TEXT, COLOR, BACKGROUND, MEDIA, MEDIA_LIST, INTERVAL, OFFSET, FALLOFF, POSITION, DIRECTION, TARGET, WAYPOINTS, TARGET_VELOCITY, STRENGTH, COUNTDOWN, SHOW, PROPERTIES, ACTIONS, NAMES, USE, TYPES, NATURAL_GRAVITY, ARTIFICIAL_GRAVITY, ALTITUDE, WEIGHT, DATA, INFO }
-        public enum ValueProperty { AMOUNT, CREATE, DESTROY, PROPERTY, ACTION };
-        public enum Direction { UP, DOWN, LEFT, RIGHT, FORWARD, BACKWARD, CLOCKWISE, COUNTERCLOCKWISE, NONE }
+        public enum Property { 
+            ENABLE,
+            POWER,
+            CONNECTED,
+            LOCKED,
+            COMPLETE,
+            OPEN,
+            TRIGGER,
+            SUPPLY,
+            AUTO,
+            OVERRIDE,
+            LEVEL,
+            ANGLE,
+            VELOCITY,
+            RATIO,
+            FONT,
+            VOLUME,
+            RANGE,
+            INPUT,
+            ROLL_INPUT,
+            NAME,
+            RUN,
+            TEXT,
+            COLOR,
+            BACKGROUND,
+            MEDIA,
+            MEDIA_LIST,
+            INTERVAL,
+            OFFSET,
+            FALLOFF,
+            POSITION,
+            DIRECTION,
+            TARGET,
+            WAYPOINTS,
+            TARGET_VELOCITY,
+            STRENGTH,
+            COUNTDOWN,
+            SHOW,
+            PROPERTIES,
+            ACTIONS,
+            NAMES,
+            USE,
+            TYPES,
+            NATURAL_GRAVITY,
+            ARTIFICIAL_GRAVITY,
+            ALTITUDE,
+            WEIGHT,
+            DATA,
+            INFO,
+            REVERSE, 
+
+            //Value Properties
+            AMOUNT,
+            CREATE,
+            DESTROY,
+            PROPERTY,
+            ACTION,
+
+            //Direction Properties
+            UP,
+            DOWN,
+            LEFT,
+            RIGHT,
+            FORWARD,
+            BACKWARD,
+            CLOCKWISE,
+            COUNTERCLOCKWISE
+        }
+
         public enum ProgramState { RUNNING, STOPPED, COMPLETE, PAUSED }
         public enum Return { NUMERIC, BOOLEAN, STRING, VECTOR, COLOR, LIST, DEFAULT }
         public enum BiOperand { ADD, SUBTRACT, MULTIPLY, DIVIDE, MOD, AND, OR, COMPARE, DOT, EXPONENT, RANGE, CAST, CONTAINS, SPLIT, JOIN, ROUND };

--- a/EasyCommands/Common/Utilities.cs
+++ b/EasyCommands/Common/Utilities.cs
@@ -28,6 +28,7 @@ namespace IngameScript {
 
         //Utilities for constructing collections with few characters
         public static List<T> NewList<T>(params T[] elements) => new List<T>(elements);
+        public static T[] NewArray<T>(params T[] elements) => elements;
         public static Dictionary<T, U> NewDictionary<T, U>(params KeyValuePair<T, U>[] elements) => elements.ToDictionary(e => e.Key, e => e.Value);
         public static KeyValuePair<T, U> KeyValuePair<T, U>(T key, U value) => new KeyValuePair<T, U>(key, value);
         public static Variable EmptyList() => GetStaticVariable(NewKeyedList());


### PR DESCRIPTION
This is my first attempt at consolidating property support, which removes VariableProperty and Direction.

Upon inspection, it's likely a bridge too far, or at least to start with.  There are too many cases where "moving" a property requires special property handler support in the new system, that wasn't required in the old.

This will serve as a template though for a smaller change to add multi-property support, without removing Directional support.

## Overview

This PR is attempting to remove the distinction between "Directions" (UP/DOWN/LEFT/RIGHT) and "PROPERTIES", by converting directions to properties, and allowing property resolution over a set of properties (vs just one).

The end state is that multiple propertyIds can be used to provide specificity on what you are trying to read/write from a property, where the structure sounds very natural.  For example:

```
#2 Properties, "Deviation" and "Angle"
set the "Custom TurretController" deviation angle to 5

#2 Properties, "Steering" and "Inverted"
if the "Front Wheels" steering is inverted
  Print "My steering is inverted"
```

As part of this change I also 

## Specific Changes
* Converted ValueProperty and Direction to Properties
* Added PropertyValue to encapsulate property type, word, and attribute in the event there are more than 1
* Changed parameter processors using directions to use lists of properties instead.
* Created hashing function to produce consistent hashes for unique sets of property ids.
* Replaced default direction with a simple "default property".  Note this may need to be updated to a default property hash, in case the default property for a block happens to be a set of properties (unlikely, but *shrug*).  
* Removed now unnecessary BlockHandler methods for getting/setting/moving via direction.
* Updated AddPropertyHandler of BlockHandler<T> to accept a params list of PropertyIds, so that you can specifically add properties for a set of propertyIds without too many additional chars.  Left existing AddXHandler APIs as is to reduce the change footprint, but these could be changed later.  
* Started modifying some of the existing BLockHandlers that used DirectionalTypeHandlers to define their own property lookups, instead.  Some of these may not be needed if we fix the "Raise"/"Lower" issue, but any using DirectionalTypeHandlers will need to be updated.

## Challenges
### Property Resolution
Previously properties were looked up by the property id (as a string).  With multi-property support lookup, this no longer works.  Additionally, the intention is that a set of properties should resolve to the same "handler".  To support this, some form of hash is needed which is consistently computed regardless of ordering (property1+property2 = property2 + property1). Example:

```
# These should use the same property handler
invert my "Test Wheel" steering
if my "Test Wheel" steering is inverted
```

I think the best way to do this is to sum up the hashcodes (unsigned and converted to long to avoid stack overflow) and use the sum as the hash.  I started with XOR but realized that property1 + property2 + property1 would equal property2, which is a problem.  Needs to be updated to use sums.  

### Dynamic Properties
Previously dynamic property support assumes only 1 input property.  Updates were needed in Properties to support multiple dynamic properties being specified.  In addition, the propertyId resolution for TerminalBlockHandler needed to change in case there happened to be multiple propertyIds passed.  My simple solution was to just concat them together (almost guaranteed to fail), and update the output "does not have propertyId" to also do this.  Note that I changed the output to always use the propertyWord instead of  falling back to propertyType.  The constructor for PropertyValue now defaults propertyWord to propertyType if not passed, so propertyWord is always present.

### Directional Support
Previously you could increase or decrease a property by "moving" it in a direction.  This was particularly useful for Raising and Lowering property values.  Example:

```
raise the "Test Piston" height to 5
```

Getting rid of directions, this is becoming a bit more challenging.  Previously properties that didn't have "directions" would simply ignore the fact that you passed a direction, and so had the effect of setting the property value.  However, in the new world, "raise height" equates to "Property.UP + Property.LEVEL", which must be explicitly mapped if you want to support this.  

In addition, previously if you did not specify a specific value, (like 5), the effect would "move" a property, which for most properties had the effect of incrementing/decrementing unless you overrode the behavior on the block handler.

```
#Overridden to call "extend"
raise the "Test Piston"

#Incremented by the default amount
raise the "Test Beacon" range
```

It's mostly just the "raise" and "lower" keywords but there are a few other challenges as well.  Here's an example list:

```
raise the piston //Extend
raise the piston to 5 //Set piston height to 5
raise the piston height //Extend
raise the piston height to 5 //Set piston height to 5
raise the piston upper limit //Increment upper limit by default amount for limit property
raise the piston upper limit to 6 //set upper limit property to 6
raise the piston lower limit //increment lower limit by default amount for limit property
raise the piston lower limit to 4 //set lower limit property to 4

set the piston to 5 //set piston height to 5
set the piston height to 5 //set piston height to 5
set the upper piston limit to 6 //set upper limit to 6
set the piston lower limit to 4 //set lower limit to 4

lower the piston//Retract the piston
lower the piston height //Retract the piston
lower the piston limit to 6 //set the piston limit property to 6
lower the piston upper limit to 4 //set the piston upper limit property to 4
lower the piston upper limit//lower the piston upper limit property by the default amount for the limit property

reverse the piston //reverse the piston
reverse the piston height //reverse the piston
reverse the piston velocity //velocity *= -1
```




### Attribute Property Lookup
Previously the attribute lookup for the Assembler & Cargo was easy, since there was only 1 attribute.  Now you need to look through each supplied PropertyValue and find the first attributeValue.  I took the opportunity to consolidate the "getRequestedAmount" and "GetItemFilteR" methods into a single one, but this is not strictly necessary.


## Possible Solutions
One thought I had was to re-map "raise" to a specific new type of parameter, and look for this type of parameter in the BlockCommand processor.  If "raise" is included along with a variable, ignore the "UP" property and call.  If no value is set, add the "Up" property to the supplier.

Lower is a bit more tricky, since lower could be an action, or just a Property:
```
#Action
lower the "Test Piston"

#Just a property specifieer
set the "Test Piston" lower limit to 5
```

I think we might be able to add a rule that says "if Lower, and lower is the first parameter, then it is an action, otherwise it just a property specifier".  This might also be usable for Raise, actually.  If the first parameter is "Up" or "Down" property, convert it to the action increment form?

With these two changes, I think we will have backwards compatibility with the existing script?  










