### PR TITLE
Proper Mock for `GridTerminalSystem`

### DIFF
--- a/EasyCommands.Tests/EasyCommands.Tests.csproj
+++ b/EasyCommands.Tests/EasyCommands.Tests.csproj
@@ -142,6 +142,7 @@
     <Compile Include="ParameterParsingTests\SimpleVariableParameterProcessorTests.cs" />
     <Compile Include="ParameterParsingTests\AggregateBlockPropertyProcessorTests.cs" />
     <Compile Include="ParameterParsingTests\TransferCommandProcessorTests.cs" />
+    <Compile Include="ScriptTests\MockGridTerminalSystem.cs" />
     <Compile Include="ScriptTests\FunctionalTests\BlockHandlers\HeatVentBlockTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\BlockHandlers\AirVentBlockTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\BlockHandlers\BeaconBlockTests.cs" />

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Commands/SimpleCommandExecutionTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Commands/SimpleCommandExecutionTests.cs
@@ -188,7 +188,7 @@ print 'Hello New World'
                 test.RunOnce();
                 Assert.AreEqual(1, test.Logger.Count);
                 Assert.AreEqual("Hello World", test.Logger[0]);
-                test.setScript(newScript);
+                test.SetScript(newScript);
                 test.Logger.Clear();
                 test.RunOnce();
                 Assert.AreEqual(1, test.Logger.Count);
@@ -212,7 +212,7 @@ print myValue";
                 test.RunOnce();
                 Assert.AreEqual(1, test.Logger.Count);
                 Assert.AreEqual("Hello World", test.Logger[0]);
-                test.setScript(newScript);
+                test.SetScript(newScript);
                 test.Logger.Clear();
                 test.RunOnce();
                 Assert.AreEqual(1, test.Logger.Count);

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/MessageHandlingTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/MessageHandlingTests.cs
@@ -60,7 +60,7 @@ print 'Hello World 2'
                 Assert.AreEqual("Incoming Message", test.Logger[0]);
                 test.Logger.Clear();
 
-                test.setScript(@"print 'Hello World 2'");
+                test.SetScript(@"print 'Hello World 2'");
                 test.MockMessages("channel", "print message1", "print message2");
 
                 test.RunOnce();

--- a/EasyCommands.Tests/ScriptTests/MockGridTerminalSystem.cs
+++ b/EasyCommands.Tests/ScriptTests/MockGridTerminalSystem.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Moq;
+using System.Threading.Tasks;
+using Sandbox.ModAPI.Ingame;
+using Sandbox.ModAPI.Interfaces;
+using VRage;
+using VRageMath;
+using VRage.Game;
+using VRage.Game.ModAPI.Ingame;
+using VRage.ObjectBuilders;
+using VRage.Utils;
+
+namespace EasyCommands.Tests.ScriptTests {
+
+    public class MockBlockGroup : Mock<IMyBlockGroup> {
+        List<IMyTerminalBlock> mockBlocks = new List<IMyTerminalBlock>();
+
+        public int BlockCount => mockBlocks.Count;
+
+        public MockBlockGroup(string name) {
+            Setup(g => g.Name).Returns(name);
+            Setup(g => g.GetBlocks(It.IsAny<List<IMyTerminalBlock>>(), It.IsAny<Func<IMyTerminalBlock, bool>>()))
+                .Callback<List<IMyTerminalBlock>, Func<IMyTerminalBlock, bool>>((blocks,collect) => {
+                    blocks.Clear();
+                    blocks.AddRange(mockBlocks.Where(collect ?? (b => true)));
+                });
+        }
+
+        public void AddBlock<T>(Mock<T> block) where T : class, IMyTerminalBlock => mockBlocks.Add(block.Object);
+        public void AddBlocks<T>(IEnumerable<Mock<T>> blocks) where T : class, IMyTerminalBlock  => mockBlocks.AddRange(blocks.Select(b => b.Object));
+        public List<IMyTerminalBlock> GetBlocks() => mockBlocks;
+    }
+
+    public class MockGridTerminalSystem : Mock<IMyGridTerminalSystem> {
+        HashSet<IMyTerminalBlock> mockBlocks = new HashSet<IMyTerminalBlock>();
+        HashSet<IMyBlockGroup> mockGroups = new HashSet<IMyBlockGroup>();
+
+        public int BlockCount => mockBlocks.Count;
+        public int GroupCount => mockGroups.Count;
+
+        public MockGridTerminalSystem() {
+            Setup(g => g.GetBlocks(It.IsAny<List<IMyTerminalBlock>>()))
+                .Callback<List<IMyTerminalBlock>>(blocks => {
+                    blocks.Clear();
+                    blocks.AddRange(mockBlocks);
+                });
+            Setup(g => g.GetBlockGroupWithName(It.IsAny<string>()))
+                .Returns<string>(name => mockGroups.FirstOrDefault(g => g.Name == name));
+        }
+
+        public void AddBlock<T>(Mock<T> block) where T : class, IMyTerminalBlock => mockBlocks.Add(block.Object);
+        public void AddBlocks<T>(IEnumerable<Mock<T>> blocks) where T : class, IMyTerminalBlock => blocks.ForEach(block => mockBlocks.Add(block.Object));
+        public void AddGroup(MockBlockGroup blockGroup) {
+            mockGroups.Add(blockGroup.Object);
+            mockBlocks.UnionWith(blockGroup.GetBlocks());
+        }
+    }
+}


### PR DESCRIPTION
Mocks for `IMyGridTerminalSystem` and `IMyBlockGroup`.

The same could be done for `IMyIntergridCommunicationSystem` and `IMyBroadcastListener`  should they be tested directly.