### PR TITLE
Do not leak `PROGRAM`

### DIFF
--- a/EasyCommands.Tests/ParameterParsingTests/AggregateBlockPropertyProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/AggregateBlockPropertyProcessorTests.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
-using Malware.MDKUtilities;
 using IngameScript;
 using static IngameScript.Program;
+using static EasyCommands.Tests.ParameterParsingTests.ParsingTestUtility;
 
 namespace EasyCommands.Tests.ParameterParsingTests {
     [TestClass]
@@ -12,7 +12,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignCountOfBlocks() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to count of the \"forward guns\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -23,7 +23,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AggregatePropertyUsedInComparison() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("wait if count of the \"forward guns\" is 0");
             Assert.IsTrue(command is ConditionalCommand);
             ConditionalCommand conditionalCommand = (ConditionalCommand)command;
@@ -38,7 +38,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSumOfBlocks() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to sum of the \"forward guns\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -49,7 +49,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignAverageOfBlocks() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to average of the \"forward guns\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -60,7 +60,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignMinimumOfBlocks() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to minimum of the \"forward guns\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -71,7 +71,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignMaximumOfBlocks() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to maximum of the \"forward guns\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -82,7 +82,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSumOfBlocksWithProperty() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to sum of the \"forward guns\" range");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -93,7 +93,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSumOfBlocksWithVariableProperty() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to sum of the \"cargo containers\" \"gold ingot\" amount");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -106,7 +106,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignAverageOfBlocksWithPropertyFirst() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to avg range of the \"forward guns\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -117,7 +117,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignAvgOfBlocksWithSelectorFirst() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to \"forward guns\" average range");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -128,7 +128,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignAvgOfBlocksWithAggregationFirst() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to \"forward guns\" range average");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -139,7 +139,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignAvgOfBlocksUsingImplicitSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to the average gun range");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -152,7 +152,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSumOfBlocksUsingImplicitAggregate() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to the \"test gun\" range");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -165,7 +165,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSumOfBlocksUsingImplicitAggregateInParentheses() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to the ( \"test gun\" range )" );
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -178,7 +178,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSumOfBlocksUsingImplicitAggregateAndImplicitSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to the gun range");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -191,7 +191,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSumOfBlocksUsingImplicitAggregateAndMySelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to my location");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;

--- a/EasyCommands.Tests/ParameterParsingTests/BlockCommandProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/BlockCommandProcessorTests.cs
@@ -1,15 +1,15 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using Malware.MDKUtilities;
 using IngameScript;
 using static IngameScript.Program;
+using static EasyCommands.Tests.ParameterParsingTests.ParsingTestUtility;
 
 namespace EasyCommands.Tests.ParameterParsingTests {
     [TestClass]
     public class SimpleBlockCommandParameterProcessorTests : ForceLocale {
         [TestMethod]
         public void SimpleBlockCommandWithProperty() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("turn on the \"pistons\"");
             Assert.IsTrue(command is BlockCommand);
 
@@ -19,63 +19,63 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SimpleBlockCommandWithPropertyUsingAssign() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign the \"pistons\" height to 10");
             Assert.IsTrue(command is BlockCommand);
         }
 
         [TestMethod]
         public void SimpleBlockCommandWithValueProperty() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("set the \"test cargo\" \"gold ingot\" amount to 0");
             Assert.IsTrue(command is BlockCommand);
         }
 
         [TestMethod]
         public void SimpleBlockCommandWithValuePropertyBeforeValue() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("set the amount of \"gold ingot\" in the \"test cargo\" to 0");
             Assert.IsTrue(command is BlockCommand);
         }
 
         [TestMethod]
         public void SimpleBlockCommandWithNotProperty() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("tell the \"rockets\" not to shoot");
             Assert.IsTrue(command is BlockCommand);
         }
 
         [TestMethod]
         public void SimpleBlockCommandWithValue() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("set the \"pistons\" to 2");
             Assert.IsTrue(command is BlockCommand);
         }
 
         [TestMethod]
         public void SimpleBlockCommandWithVariableValue() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("set the \"pistons\" to {b}");
             Assert.IsTrue(command is BlockCommand);
         }
 
         [TestMethod]
         public void SimpleBlockCommandWithDirection() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("retract the \"pistons\"");
             Assert.IsTrue(command is BlockCommand);
         }
 
         [TestMethod]
         public void SimpleBlockCommandWithReverse() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("reverse the \"pistons\"");
             Assert.IsTrue(command is BlockCommand);
         }
 
         [TestMethod]
         public void SimpleBlockCommandWithPropertyAndVariable() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("set the \"pistons\" height to 2");
             Assert.IsTrue(command is BlockCommand);
 
@@ -85,7 +85,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SimpleBlockCommandWithDirectionAndVariable() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("rotate the \"rotors\" clockwise to 30");
             Assert.IsTrue(command is BlockCommand);
 
@@ -95,7 +95,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SimpleBlockCommandWithDirectionAndPropertyAndVariable() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("rotate the \"rotors\" angle clockwise to 30");
             Assert.IsTrue(command is BlockCommand);
 
@@ -105,7 +105,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SimpleBlockCommandUsingImplicitBlockPropertyValue() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("rotate the \"rotors\" to the \"rotors\" upper limit");
             Assert.IsTrue(command is BlockCommand);
         }

--- a/EasyCommands.Tests/ParameterParsingTests/BooleanLogicParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/BooleanLogicParameterProcessorTests.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using Malware.MDKUtilities;
 using IngameScript;
 using static IngameScript.Program;
 using static EasyCommands.Tests.ParameterParsingTests.ParsingTestUtility;
@@ -10,70 +9,70 @@ namespace EasyCommands.Tests.ParameterParsingTests {
     public class BooleanLogicParameterProcessorTests : ForceLocale {
         [TestMethod]
         public void AndSimpleVariableCondition() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("if true and false turn on the \"pistons\"");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void AndBlockCondition() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("if the \"batteries\" are on but are not recharging turn on the \"generators\"");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void AndAggregateConditions() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("if the \"batteries\" are on but none of the \"batteries\" is recharging turn on the \"generators\"");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void OrSimpleVariableCondition() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("if true or false turn on the \"pistons\"");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void OrBlockCondition() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("if any of the \"batteries\" ratio is less than 0.5 or is recharging turn on the \"pistons\"");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void OrAggregateConditions() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("if the \"batteries\" are off or any of the \"batteries\" ratio is less than 0.25 turn on the \"generators\"");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void NotVariableCondition() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("if not true turn on the \"pistons\"");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void NotBlockCondition() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("if not true turn on the \"pistons\"");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void NotAggregateBlockCondition() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("if not all of the \"batteries\" ratio > 0.75 turn on the \"generators\"");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void ImplicitSelectorUsedInAggregateCondition() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("if any battery ratio < 0.75 turn on the generators");
             Assert.IsTrue(command is ConditionalCommand);
             ConditionalCommand conditionalCommand = (ConditionalCommand)command;
@@ -93,7 +92,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ImplicitSelectorUsedInAggregateConditionWithNot() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("if not all of the batteries ratio < 0.75 turn on the generators");
             Assert.IsTrue(command is ConditionalCommand);
             ConditionalCommand conditionalCommand = (ConditionalCommand)command;

--- a/EasyCommands.Tests/ParameterParsingTests/ConditionalParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/ConditionalParameterProcessorTests.cs
@@ -1,15 +1,15 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using Malware.MDKUtilities;
 using IngameScript;
 using static IngameScript.Program;
+using static EasyCommands.Tests.ParameterParsingTests.ParsingTestUtility;
 
 namespace EasyCommands.Tests.ParameterParsingTests {
     [TestClass]
     public class ConditionalParameterProcessorTests : ForceLocale {
         [TestMethod]
         public void SimpleBooleanCondition() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("if true set the \"rotors\" height to 5");
             Assert.IsTrue(command is ConditionalCommand);
             ConditionalCommand conditionalCommand = (ConditionalCommand)command;
@@ -21,7 +21,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SimpleVariableCondition() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("if a set the \"rotors\" height to 5");
             Assert.IsTrue(command is ConditionalCommand);
             ConditionalCommand conditionalCommand = (ConditionalCommand)command;
@@ -32,7 +32,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void VariableComparisonCondition() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("if 3 > 2 set the \"rotors\" height to 5");
             Assert.IsTrue(command is ConditionalCommand);
             ConditionalCommand conditionalCommand = (ConditionalCommand)command;
@@ -46,7 +46,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void BlockConditionWithProperty() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("if the \"batteries\" are recharging set the \"rotors\" height to 5");
             Assert.IsTrue(command is ConditionalCommand);
             ConditionalCommand conditionalCommand = (ConditionalCommand)command;

--- a/EasyCommands.Tests/ParameterParsingTests/IteratorParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/IteratorParameterProcessorTests.cs
@@ -1,15 +1,15 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using Malware.MDKUtilities;
 using IngameScript;
 using static IngameScript.Program;
+using static EasyCommands.Tests.ParameterParsingTests.ParsingTestUtility;
 
 namespace EasyCommands.Tests.ParameterParsingTests {
     [TestClass]
     public class IteratorParameterProcessorTests : ForceLocale {
         [TestMethod]
         public void SimpleIteration() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("for each item in myItems print \"Item: \" + item");
             Assert.IsTrue(command is ForEachCommand);
             ForEachCommand forEachCommand = (ForEachCommand)command;
@@ -21,7 +21,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SimpleIterationWithPrecedingCommand() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("print \"Item: \" + item for each item in myItems");
             Assert.IsTrue(command is ForEachCommand);
             ForEachCommand forEachCommand = (ForEachCommand)command;

--- a/EasyCommands.Tests/ParameterParsingTests/ListParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/ListParameterProcessorTests.cs
@@ -3,16 +3,16 @@ using System;
 using System.Collections.Generic;
 using System.Collections;
 using System.Linq;
-using Malware.MDKUtilities;
 using IngameScript;
 using static IngameScript.Program;
+using static EasyCommands.Tests.ParameterParsingTests.ParsingTestUtility;
 
 namespace EasyCommands.Tests.ParameterParsingTests {
     [TestClass]
     public class ListParameterProcessorTests : ForceLocale {
         [TestMethod]
         public void AssignVariableToBasicStaticList() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign myList to [\"one\", \"two\", \"three\"]");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignmentCommand = (VariableAssignmentCommand)command;
@@ -30,7 +30,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVariableToBasicStaticListWithBlockType() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign myList to [\"reactor component\"]");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignmentCommand = (VariableAssignmentCommand)command;
@@ -46,7 +46,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVariableIndexToVariable() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign myList[0] to \"value\"");
             Assert.IsTrue(command is ListVariableAssignmentCommand);
             ListVariableAssignmentCommand assignmentCommand = (ListVariableAssignmentCommand)command;
@@ -62,7 +62,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVariableIndexToStaticList() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign myList[0] to [\"one\", \"two\", \"three\"]");
             Assert.IsTrue(command is ListVariableAssignmentCommand);
             ListVariableAssignmentCommand assignmentCommand = (ListVariableAssignmentCommand)command;
@@ -83,7 +83,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignMultipleVariableIndexesToStaticValue() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign myList[(0 .. 2) + [4]] to \"value\"");
             Assert.IsTrue(command is ListVariableAssignmentCommand);
             ListVariableAssignmentCommand assignmentCommand = (ListVariableAssignmentCommand)command;
@@ -101,7 +101,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVariableToListIndexValue() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign myValue to [1, 2, 3][0]");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignmentCommand = (VariableAssignmentCommand)command;
@@ -112,7 +112,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVariableToListSubRange() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign myValue to (3..10)[2..4]");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignmentCommand = (VariableAssignmentCommand)command;
@@ -126,7 +126,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignListAtIndexValuesToAnotherList() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign myList[1, 2, 3] to [0]");
             Assert.IsTrue(command is ListVariableAssignmentCommand);
             ListVariableAssignmentCommand assignmentCommand = (ListVariableAssignmentCommand)command;
@@ -145,7 +145,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVariableToMultiDimensionalArray() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign myList to [ [0,1,2] , [3,4,5] ]");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignmentCommand = (VariableAssignmentCommand)command;
@@ -166,7 +166,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVariableToMultiDimensionalArrayValue() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign myValue to [ [0,1,2] , [3,4,5] ][1][2]");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignmentCommand = (VariableAssignmentCommand)command;
@@ -176,7 +176,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVariableToMultiDimensionalArraySubList() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign myValue to [ [0,1,2] , [3,4,5] ][1]");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignmentCommand = (VariableAssignmentCommand)command;
@@ -190,7 +190,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void CountOfListAsCondition() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("if count of shipRoute[] > 0 wait");
             Assert.IsTrue(command is ConditionalCommand);
             ConditionalCommand conditionalCommand = (ConditionalCommand)command;

--- a/EasyCommands.Tests/ParameterParsingTests/OperatorParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/OperatorParameterProcessorTests.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using VRageMath;
-using Malware.MDKUtilities;
 using IngameScript;
 using static IngameScript.Program;
 using static EasyCommands.Tests.ParameterParsingTests.ParsingTestUtility;
@@ -13,7 +12,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
     public class OperatorParameterProcessorTests : ForceLocale {
         [TestMethod]
         public void AssignAbsoluteValue() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to abs -3 + 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -25,7 +24,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSin() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to sin 1.5708");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -37,7 +36,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignCos() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to cos 1.5708");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -49,7 +48,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignTan() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to tan 1.5708");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -61,7 +60,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignASin() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to asin 1.5708");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -73,7 +72,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignACos() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to acos 1.5708");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -85,7 +84,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignATan() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to atan 1.5708");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -97,7 +96,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignNaturalLog() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to ln 1.5");
             Assert.IsTrue(command is VariableAssignmentCommand);
             var assignment = command as VariableAssignmentCommand;
@@ -109,7 +108,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSign() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to sign -0.5");
             Assert.IsTrue(command is VariableAssignmentCommand);
             var assignment = command as VariableAssignmentCommand;
@@ -121,7 +120,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignRoundDown() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to round 5.4");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -133,7 +132,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignRoundUp() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to round 5.6");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -145,7 +144,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignRoundVector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to round (5.6:0:5.4)");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -157,7 +156,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignAbsoluteValueVector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to abs 1:0:0 + 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -174,7 +173,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSquareRootValue() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to sqrt 9 + 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -186,7 +185,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSquareRootValueVector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to sqrt 9:0:0 + 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -203,7 +202,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleAddition() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 3 + 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -215,7 +214,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleSubtraction() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 3 - 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -227,7 +226,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleStringSubtraction() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to \"test\" - t");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -239,7 +238,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignNegativeVariable() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to -t");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -253,7 +252,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleStringSubtractionMultipleCharacters() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to \"second\" - eco");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -265,7 +264,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleStringSubtractionEmptyString() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to \"second\" - \"\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -277,7 +276,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleStringSubtractionLastCharacter() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to \"second\" - d");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -289,7 +288,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleStringSubtractionDoesNotContain() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to \"second\" - f");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -301,7 +300,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleStringSubtractionSubString() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to \"second\" - 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -313,7 +312,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleStringSubtractionSubStringMoreThanLength() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to \"second\" - 6");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -325,7 +324,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleMultiplication() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 3 * 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -337,7 +336,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVectorNumericAddition() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 1:0:0 + 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -349,7 +348,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVectorNumericSubtraction() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 1:0:0 - 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -361,7 +360,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVectorNumericMultiplication() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 1:0:0 * 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -373,7 +372,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVectorNumericDivision() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 2:0:0 / 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -385,7 +384,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVectorMultiplication() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 0:1:0 * 1:0:0");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -397,7 +396,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVectorDotProduct() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 0:1:0 . 1:0:0");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -409,7 +408,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVectorSign() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to sign -0.5:1.5:0");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -421,7 +420,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleDivision() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 6 / 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -433,7 +432,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleMod() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 5 % 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -445,7 +444,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignStringMod() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to test % t");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -457,7 +456,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVectorMod() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 1:1:0 % 0:1:0");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -469,7 +468,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleExponent() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 2 ^ 4");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -481,7 +480,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignBoolExponentAsXOR() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to true ^ false");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -493,7 +492,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignBoolExponentAsXORWhenFalse() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to true xor true");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -505,7 +504,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVectorExponentAsAngleBetween() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 0:0:1 ^ 1:0:0");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -517,7 +516,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleAdditionVariable() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to b + 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -530,7 +529,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleSubtractionVariable() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to b - 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -543,7 +542,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleMultiplicationVariable() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to b * 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -556,7 +555,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSimpleDivisionVariable() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to b / 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -569,7 +568,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void MultiplicationBeforeAddition() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 4 * 2 + 3");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -585,7 +584,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void DivisionBeforeAddition() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 4 / 2 + 3");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -601,7 +600,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AdditionBeforeVariableComparison() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to b + 1 > 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -613,7 +612,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AdditionBeforeBooleanLogic() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to b + 1 and c");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -626,7 +625,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void TernaryOperator() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign e to a > b ? c : d + 1");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -645,7 +644,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ComparisonBeforeBooleanLogic() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign c to a > 0 and b < 1");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -664,7 +663,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AdditionUsedAsBlockConditionVariable() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("if the \"rotor\" angle > a + 30 set the \"rotor\" angle to a");
             Assert.IsTrue(command is ConditionalCommand);
             ConditionalCommand conditionalCommand = (ConditionalCommand)command;
@@ -681,7 +680,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignColor() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to red");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -692,7 +691,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignColorFromHex() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to #ff0000");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -703,7 +702,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignAddedColors() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to #ff0000 + #00ff00");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -714,7 +713,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignSubtractedColors() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to #ffff00 - #00ff00");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -725,7 +724,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignMultipliedColor() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to #112233 * 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -736,7 +735,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignDividedColor() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to #224466 / 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -747,7 +746,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignNotColor() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to not red");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -758,7 +757,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AddNumberToList() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to [0, 1, 2] + 3");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -772,7 +771,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AddNumberToListInFront() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 0 + [1, 2, 3]");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -786,7 +785,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AddStringToList() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to [0, 1, 2] + \" three\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -795,7 +794,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AddStringToListInFront() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to \"zero \" + [0, 1, 2]");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -804,7 +803,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AddTwoLists() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to [0, 1, 2] + [3, 4, 5]");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -820,7 +819,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void CastStringAsVector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to (\"1\" + \":2:\" + \"3\") as \"vector\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -831,7 +830,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void CastStringAsBoolean() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to \"true\" as \"bool\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -842,7 +841,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SplitStringBySubString() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to \"My Value\" split \" \"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -853,7 +852,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SplitStringByNewLine() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to \"My\nValue\" split \"\\n\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -864,7 +863,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void JoinListByString() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to [1,2,3] joined \", \"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;
@@ -875,7 +874,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void JoinListByNewLine() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to [1,2,3] joined \"\\n\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignment = (VariableAssignmentCommand)command;

--- a/EasyCommands.Tests/ParameterParsingTests/ParenthesisParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/ParenthesisParameterProcessorTests.cs
@@ -1,29 +1,29 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using Malware.MDKUtilities;
 using IngameScript;
 using static IngameScript.Program;
+using static EasyCommands.Tests.ParameterParsingTests.ParsingTestUtility;
 
 namespace EasyCommands.Tests.ParameterParsingTests {
     [TestClass]
     public class ParenthesisParameterProcessorTests : ForceLocale {
         [TestMethod]
         public void BasicVariableParentheses() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("set the \"pistons\" height to ( {a} + {b} )");
             Assert.IsTrue(command is BlockCommand);
         }
 
         [TestMethod]
         public void MultipleVariableParenthesis() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("if ( {a} > {b} ) set the \"pistons\" height to ( {a} + {b} )");
             Assert.IsTrue(command is ConditionalCommand);
         }
 
         [TestMethod]
         public void EmbeddedParanthesis() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("if ( ( {a} + {b} ) > {c} ) set the \"pistons\" height to ( {a} + {b} )");
             Assert.IsTrue(command is ConditionalCommand);
             ConditionalCommand conditionalCommand = (ConditionalCommand)command;

--- a/EasyCommands.Tests/ParameterParsingTests/ParsingTestUtility.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/ParsingTestUtility.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using IngameScript;
+using Malware.MDKUtilities;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,6 +11,12 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         public static T GetDelegateProperty<T>(String propertyId, Delegate target) {
             var fields = target.Target.GetType().GetFields().Select(t => t.Name).ToList();
             return (T)target.Target.GetType().GetFields().Where(t => t.Name == propertyId).Select(t => t.GetValue(target.Target)).First();
+        }
+
+        public static Program CreateProgram() {
+            Program program = MDKFactory.CreateProgram<Program>();
+            Program.PROGRAM = program;
+            return program;
         }
     }
 }

--- a/EasyCommands.Tests/ParameterParsingTests/SelectorLogicParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SelectorLogicParameterProcessorTests.cs
@@ -3,16 +3,16 @@ using System;
 using System.Collections.Generic;
 using System.Collections;
 using System.Linq;
-using Malware.MDKUtilities;
 using IngameScript;
 using static IngameScript.Program;
+using static EasyCommands.Tests.ParameterParsingTests.ParsingTestUtility;
 
 namespace EasyCommands.Tests.ParameterParsingTests {
     [TestClass]
     public class SelectorLogicParameterProcessorTests : ForceLocale {
         [TestMethod]
         public void BasicSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("recharge the \"batteries\"");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -26,7 +26,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ConditionalSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("recharge \"batteries\" whose ratio < 0.5");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -35,7 +35,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void IndexSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("turn on \"batteries\" @ 0");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -44,7 +44,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ListIndexSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("turn on \"batteries\"[0]");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -57,7 +57,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignListIndexSelectorValuePlusList() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("set my display[0] to \"Offset: \" + [myOffset]");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -70,7 +70,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void InLineIndexSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("turn on \"batteries\" @0");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -79,7 +79,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ConditionalIndexSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("set the \"batteries\" whose ratio < 0.5 @0 to recharge");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -90,7 +90,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ConditionalIndexSelectorWithValueProperty() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("drain the \"cargo containers\" whose \"gold ingot\" amount < 0.5");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -99,7 +99,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void LastBlockTypeImpliedIsUsed() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("turn on the \"Boom Door Program\"");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -110,7 +110,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SelectorVariableSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("turn on the $a sirens");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -124,7 +124,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void VariableSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("turn on the (a + \" test\") sirens");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -138,7 +138,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
          public void AmbiguousVariableSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("turn on the a sirens");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -151,7 +151,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void StringSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand(@"turn on the ""a"" sirens");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -164,7 +164,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ExplicitStringSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand(@"turn on the 'a' sirens");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -177,7 +177,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ListVariableSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("turn on the a[0] sirens");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -196,7 +196,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void MultiDimensionalListVariableSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("turn on the a[0][1] sirens");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -221,7 +221,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SelectorVariableSelectorWithIndex() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("turn on the $mySirens[0]");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -239,7 +239,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SelectorVariableInterpretListIndexAsSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("turn on $(mySirens[0])");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -257,7 +257,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SelectorVariableInterpretListIndexAsSelectorWithBlockType() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("turn on $(mySirens[0]) sirens");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -276,7 +276,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SelectorVariableInterpretListIndexAsSelectorWithIndex() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("turn on $(mySirens[0])[1]");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -300,7 +300,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SelectorVariableSelectorWithBlockTypeAndIndex() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("turn on the $mySirens sirens [0]");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -320,7 +320,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ImplicitSelectorVariableSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("turn on the $a");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -333,7 +333,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void MySelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to my average location");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -345,7 +345,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void MySelectorWithBlockType() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("set my display @0 text to \"hello world\"");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -357,7 +357,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AllSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("set all piston height to 0");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -368,7 +368,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AllSelectorGroup() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("set the height of all pistons to 0");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -379,7 +379,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AllSelectorGroupWithCondition() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("recharge all batteries whose ratio < 0.25");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -392,7 +392,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ImplicitAllSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("turn on the light");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;
@@ -403,7 +403,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ImplicitAllGroupSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("turn on the lights");
             Assert.IsTrue(command is BlockCommand);
             BlockCommand bc = (BlockCommand)command;

--- a/EasyCommands.Tests/ParameterParsingTests/SimpleCommandProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SimpleCommandProcessorTests.cs
@@ -3,16 +3,16 @@ using System;
 using System.Collections.Generic;
 using System.Collections;
 using System.Linq;
-using Malware.MDKUtilities;
 using IngameScript;
 using static IngameScript.Program;
+using static EasyCommands.Tests.ParameterParsingTests.ParsingTestUtility;
 
 namespace EasyCommands.Tests.ParameterParsingTests {
     [TestClass]
     public class SimpleCommandProcessorTests : ForceLocale {
         [TestMethod]
         public void PrintCommand() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("print 'Hello World'");
             Assert.IsTrue(command is PrintCommand);
             PrintCommand printCommand = (PrintCommand)command;
@@ -21,7 +21,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void PrintCommandVariable() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("print a");
             Assert.IsTrue(command is PrintCommand);
             PrintCommand printCommand = (PrintCommand)command;
@@ -32,7 +32,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ListenCommand() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("listen \"garageDoors\"");
             Assert.IsTrue(command is ListenCommand);
             ListenCommand listenCommand = (ListenCommand)command;
@@ -41,7 +41,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SendCommand() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("send \"goto openDoors\" to \"garageDoors\"");
             Assert.IsTrue(command is SendCommand);
             SendCommand sendCommand = (SendCommand)command;
@@ -51,7 +51,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void FunctionCommand() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             program.functions["listen"] = new FunctionDefinition("listen", new List<string>());
             var command = program.ParseCommand("goto \"listen\"");
             Assert.IsTrue(command is FunctionCommand);
@@ -62,7 +62,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ImpliciitFunctionCommand() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             program.functions["listen"] = new FunctionDefinition("listen", new List<string>());
             var command = program.ParseCommand("\"listen\"");
             Assert.IsTrue(command is FunctionCommand);
@@ -73,7 +73,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void FunctionCommandFromExplicitString() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             program.functions["listen"] = new FunctionDefinition("listen", new List<string>());
             var command = program.ParseCommand("goto 'listen'");
             Assert.IsTrue(command is FunctionCommand);
@@ -84,7 +84,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void FunctionCommandWithParameters() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             program.functions["listen"] = new FunctionDefinition("listen", new List<string>() { "a", "b" });
             var command = program.ParseCommand("goto \"listen\" 2 3");
             Assert.IsTrue(command is FunctionCommand);
@@ -97,7 +97,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ImplicitFunctionCommandWithParameters() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             program.functions["listen"] = new FunctionDefinition("listen", new List<string>() { "a", "b" });
             var command = program.ParseCommand("\"listen\" 2 3");
             Assert.IsTrue(command is FunctionCommand);
@@ -110,7 +110,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SetVariableWithSameNameAsFunction() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             program.functions["function"] = new FunctionDefinition("function", new List<string>() { "a", "b" });
             var command = program.ParseCommand("set function to \"myFunction\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
@@ -121,7 +121,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void WaitCommandNoArguments() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("wait");
             Assert.IsTrue(command is WaitCommand);
             WaitCommand waitCommand = (WaitCommand)command;
@@ -130,7 +130,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void WaitCommandInterval() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("wait 3");
             Assert.IsTrue(command is WaitCommand);
             WaitCommand waitCommand = (WaitCommand)command;
@@ -139,7 +139,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void WaitCommandIntervalTicks() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("wait 3 ticks");
             Assert.IsTrue(command is WaitCommand);
             WaitCommand waitCommand = (WaitCommand)command;
@@ -148,7 +148,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void IterateSimpleCommand() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("print \"hello world\" 3 times");
             Assert.IsTrue(command is MultiActionCommand);
             MultiActionCommand iterateCommand = (MultiActionCommand)command;
@@ -162,7 +162,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void IterateSimpleCommandAfter() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("for 3 times print \"hello world\"");
             Assert.IsTrue(command is MultiActionCommand);
             MultiActionCommand iterateCommand = (MultiActionCommand)command;

--- a/EasyCommands.Tests/ParameterParsingTests/SimpleVariableParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/SimpleVariableParameterProcessorTests.cs
@@ -1,16 +1,16 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using VRageMath;
-using Malware.MDKUtilities;
 using IngameScript;
 using static IngameScript.Program;
+using static EasyCommands.Tests.ParameterParsingTests.ParsingTestUtility;
 
 namespace EasyCommands.Tests.ParameterParsingTests {
     [TestClass]
     public class SimpleVariableParameterProcessorTests :ForceLocale {
         [TestMethod]
         public void AssignVariable() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -21,7 +21,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVariableWithActionKeyword() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("set a to 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -32,7 +32,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void IncrementVariable() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("increase i");
             Assert.IsTrue(command is VariableIncrementCommand);
             VariableIncrementCommand incrementCommand = (VariableIncrementCommand)command;
@@ -43,7 +43,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void IncrementVariablePre() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("++i");
             Assert.IsTrue(command is VariableIncrementCommand);
             VariableIncrementCommand incrementCommand = (VariableIncrementCommand)command;
@@ -54,7 +54,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void IncrementVariablePost() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("i++");
             Assert.IsTrue(command is VariableIncrementCommand);
             VariableIncrementCommand incrementCommand = (VariableIncrementCommand)command;
@@ -65,7 +65,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void IncrementVariableValue() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("increase i by 2");
             Assert.IsTrue(command is VariableIncrementCommand);
             VariableIncrementCommand incrementCommand = (VariableIncrementCommand)command;
@@ -76,7 +76,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void IncrementVariableByVariableValue() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("increase i by j");
             Assert.IsTrue(command is VariableIncrementCommand);
             VariableIncrementCommand incrementCommand = (VariableIncrementCommand)command;
@@ -88,7 +88,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void IncrementVariableValuePost() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("i+=2");
             Assert.IsTrue(command is VariableIncrementCommand);
             VariableIncrementCommand incrementCommand = (VariableIncrementCommand)command;
@@ -99,7 +99,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void IncrementVariableValuePostVariable() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("i+=j");
             Assert.IsTrue(command is VariableIncrementCommand);
             VariableIncrementCommand incrementCommand = (VariableIncrementCommand)command;
@@ -111,7 +111,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void DecrementVariablePre() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("--i");
             Assert.IsTrue(command is VariableIncrementCommand);
             VariableIncrementCommand incrementCommand = (VariableIncrementCommand)command;
@@ -122,7 +122,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void DecrementVariablePost() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("i--");
             Assert.IsTrue(command is VariableIncrementCommand);
             VariableIncrementCommand incrementCommand = (VariableIncrementCommand)command;
@@ -133,7 +133,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void DecrementVariableValue() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("decrease i by 2");
             Assert.IsTrue(command is VariableIncrementCommand);
             VariableIncrementCommand incrementCommand = (VariableIncrementCommand)command;
@@ -144,7 +144,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void DecrementVariableValuePost() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("i-=2");
             Assert.IsTrue(command is VariableIncrementCommand);
             VariableIncrementCommand incrementCommand = (VariableIncrementCommand)command;
@@ -155,7 +155,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignGlobalVariable() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign global a to 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -167,7 +167,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignGlobalVariableWithActionKeyword() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("set global a to 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -179,7 +179,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVariableFromInMemoryVariableName() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -190,7 +190,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVariableToAmbiguousStringValue() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to b");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -201,7 +201,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVariableToImplicitVariableReference() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var thread = new Thread(new NullCommand(), "test", "test");
             program.currentThread = thread;
             program.SetGlobalVariable("b", GetStaticVariable(4));
@@ -215,7 +215,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVariableCaseIsPreserved() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to variableName");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -227,7 +227,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void LockVariable() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("bind a to b is 2");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -243,7 +243,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ParseSimpleVector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to 53573.9750085028:-26601.8512032533:12058.8229348438");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -257,7 +257,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void ParseVectorFromGPSCoordinate() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign a to \"GPS:surface:53573.9750085028:-26601.8512032533:12058.8229348438:#FF75C9F1:\" as vector");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -271,35 +271,35 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVariableToSelectorProperty() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign vector to avg \"Main Cockpit\" position");
             Assert.IsTrue(command is VariableAssignmentCommand);
         }
 
         [TestMethod]
         public void AssignVariableToCountOfGroupSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("set myValue to the count of \"My Batteries\" batteries");
             Assert.IsTrue(command is VariableAssignmentCommand);
         }
 
         [TestMethod]
         public void AssignVariableToCountOfImplicitSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("set myValue to the count of \"My Batteries\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
         }
 
         [TestMethod]
         public void AssignVariableToCountOfAllGroupSelector() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("set myValue to the count of my batteries");
             Assert.IsTrue(command is VariableAssignmentCommand);
         }
 
         [TestMethod]
         public void AssignVariableToMySelectorProperty() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("set myPosition to my position");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignCommand = (VariableAssignmentCommand)command;
@@ -307,7 +307,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void AssignVariableToSelectorString() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("assign mySelector to \"Main Cockpit\"");
             Assert.IsTrue(command is VariableAssignmentCommand);
             VariableAssignmentCommand assignmentCommand = (VariableAssignmentCommand)command;

--- a/EasyCommands.Tests/ParameterParsingTests/TransferCommandProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/TransferCommandProcessorTests.cs
@@ -1,15 +1,15 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using Malware.MDKUtilities;
 using IngameScript;
 using static IngameScript.Program;
+using static EasyCommands.Tests.ParameterParsingTests.ParsingTestUtility;
 
 namespace EasyCommands.Tests.ParameterParsingTests {
     [TestClass]
     public class TransferCommandProcessorTests : ForceLocale {
         [TestMethod]
         public void SimpleTransfer() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("transfer \"gold ingot\" from \"source cargo\" to \"destination cargo\"");
             Assert.IsTrue(command is TransferItemCommand);
             TransferItemCommand transferCommand = (TransferItemCommand)command;
@@ -25,7 +25,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SimpleTransferWithAmount() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("transfer 50 \"gold ingot\" from \"source cargo\" to \"destination cargo\"");
             Assert.IsTrue(command is TransferItemCommand);
             TransferItemCommand transferCommand = (TransferItemCommand)command;
@@ -41,7 +41,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void TransferAfterSource() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("\"source cargo\" transfer \"gold ingot\" to \"destination cargo\"");
             Assert.IsTrue(command is TransferItemCommand);
             TransferItemCommand transferCommand = (TransferItemCommand)command;
@@ -57,7 +57,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void TransferAfterSourceWithAmount() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("\"source cargo\" transfer 50 \"gold ingot\" to \"destination cargo\"");
             Assert.IsTrue(command is TransferItemCommand);
             TransferItemCommand transferCommand = (TransferItemCommand)command;
@@ -73,7 +73,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SimpleTake() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("take \"gold ingot\" from \"source cargo\" to \"destination cargo\"");
             Assert.IsTrue(command is TransferItemCommand);
             TransferItemCommand transferCommand = (TransferItemCommand)command;
@@ -89,7 +89,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void SimpleTakeWithAmount() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("take 50 \"gold ingot\" from \"source cargo\" to \"destination cargo\"");
             Assert.IsTrue(command is TransferItemCommand);
             TransferItemCommand transferCommand = (TransferItemCommand)command;
@@ -105,7 +105,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void TakeAfterDestination() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("\"destination cargo\" take \"gold ingot\" from \"source cargo\"");
             Assert.IsTrue(command is TransferItemCommand);
             TransferItemCommand transferCommand = (TransferItemCommand)command;
@@ -121,7 +121,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
 
         [TestMethod]
         public void TakeAfterDestinationWithAmount() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var command = program.ParseCommand("\"destination cargo\" take 50 \"gold ingot\" from \"source cargo\"");
             Assert.IsTrue(command is TransferItemCommand);
             TransferItemCommand transferCommand = (TransferItemCommand)command;

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Commands/BlockCommandTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Commands/BlockCommandTests.cs
@@ -395,7 +395,7 @@ namespace EasyCommands.Tests.ScriptTests {
 
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("IMyBeacon does not have property: angle", test.Logger[1]);
             }
         }
@@ -410,7 +410,7 @@ namespace EasyCommands.Tests.ScriptTests {
 
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("IMyInventory does not have property: angle", test.Logger[1]);
             }
         }
@@ -424,7 +424,7 @@ namespace EasyCommands.Tests.ScriptTests {
 
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("IMyBeacon does not have property: attach", test.Logger[1]);
             }
         }
@@ -450,7 +450,7 @@ namespace EasyCommands.Tests.ScriptTests {
 
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("IMyBeacon does not have property: angle", test.Logger[1]);
             }
         }
@@ -465,7 +465,7 @@ namespace EasyCommands.Tests.ScriptTests {
 
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("IMyInventory does not have property: angle", test.Logger[1]);
             }
         }

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Commands/ControlCommandTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Commands/ControlCommandTests.cs
@@ -150,7 +150,7 @@ break
             using (var test = new ScriptTest(script)) {
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Invalid use of break command", test.Logger[1]);
             }
         }
@@ -166,7 +166,7 @@ continue
             using (var test = new ScriptTest(script)) {
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Invalid use of continue command", test.Logger[1]);
             }
         }
@@ -183,7 +183,7 @@ queue
             using (var test = new ScriptTest(script)) {
                 test.RunUntilDone();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Invalid use of return command", test.Logger[1]);
             }
         }
@@ -317,7 +317,7 @@ until i > 5
   if i % 2 is 0
     continue
   Print ""i is: "" + i
-  
+
   set k to 0
   until k > 5
     k++

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Commands/FunctionCommandTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Commands/FunctionCommandTests.cs
@@ -271,7 +271,7 @@ print ""Done""
                 test.RunOnce();
 
                 Assert.AreEqual(2, test.Logger.Count);
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Invalid Function Name: myFunction", test.Logger[1]);
             }
         }
@@ -290,7 +290,7 @@ print ""Done""
                 test.RunOnce();
 
                 Assert.AreEqual(2, test.Logger.Count);
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Invalid Function Name: myFunction", test.Logger[1]);
             }
         }
@@ -310,7 +310,7 @@ print ""Hello World""
                 test.RunOnce();
 
                 Assert.AreEqual(2, test.Logger.Count);
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Function myFunction expects 2 parameters", test.Logger[1]);
             }
         }
@@ -332,7 +332,7 @@ print ""Hello World""
                 test.RunOnce();
 
                 Assert.AreEqual(2, test.Logger.Count);
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Function myFunction expects 2 parameters", test.Logger[1]);
             }
         }

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/Comparisons/SimpleInvalidComparisonsTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/Comparisons/SimpleInvalidComparisonsTests.cs
@@ -61,7 +61,7 @@ namespace EasyCommands.Tests.ScriptTests {
             using (var test = new ScriptTest("print " + value1 + " = " + value2)) {
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Cannot perform operation: compare on types: " + type1 + ", " + type2, test.Logger[1]);
             }
 

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/RoundOperatorTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/RoundOperatorTests.cs
@@ -97,7 +97,7 @@ namespace EasyCommands.Tests.ScriptTests {
 
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Cannot perform operation: round on type: string", test.Logger[1]);
             }
         }
@@ -108,7 +108,7 @@ namespace EasyCommands.Tests.ScriptTests {
 
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Cannot perform operation: round on types: string, number", test.Logger[1]);
             }
         }
@@ -119,7 +119,7 @@ namespace EasyCommands.Tests.ScriptTests {
 
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Cannot perform operation: round on types: number, string", test.Logger[1]);
             }
         }

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/SimpleCastTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/SimpleCastTests.cs
@@ -418,7 +418,7 @@ Print ""0:0:0"" as bool
                 Assert.AreEqual("False", test.Logger[5]);
                 Assert.AreEqual("True", test.Logger[6]);
                 Assert.AreEqual("False", test.Logger[7]);
-                Assert.AreEqual("Exception Occurred:", test.Logger[8]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[8]);
                 Assert.AreEqual("Cannot convert vector 0:0:0 to boolean", test.Logger[9]);
             }
         }
@@ -428,7 +428,7 @@ Print ""0:0:0"" as bool
             using (var test = new ScriptTest(@"Print 0:0:1 as bool")) {
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Cannot convert vector 0:0:1 to boolean", test.Logger[1]);
             }
         }
@@ -438,7 +438,7 @@ Print ""0:0:0"" as bool
             using (var test = new ScriptTest(@"Print #ffffff as bool")) {
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Cannot convert color #FFFFFF to boolean", test.Logger[1]);
             }
         }
@@ -448,7 +448,7 @@ Print ""0:0:0"" as bool
             using (var test = new ScriptTest(@"Print [0, 1, 2] as bool")) {
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Cannot convert list [0,1,2] to boolean", test.Logger[1]);
             }
         }
@@ -500,7 +500,7 @@ Print ""abc"" as number
                 Assert.AreEqual("1", test.Logger[0]);
                 Assert.AreEqual("0", test.Logger[1]);
                 Assert.AreEqual("1.5", test.Logger[2]);
-                Assert.AreEqual("Exception Occurred:", test.Logger[3]);
+                Assert.AreEqual("System Exception Occurred:", test.Logger[3]);
             }
         }
 
@@ -518,7 +518,7 @@ Print ""abc"" as number
             using (var test = new ScriptTest(@"Print #ffffff as number")) {
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Cannot convert color #FFFFFF to number", test.Logger[1]);
             }
         }
@@ -530,7 +530,7 @@ Print ""abc"" as number
             {
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Cannot convert list [0,1,2] to number", test.Logger[1]);
             }
         }
@@ -610,7 +610,7 @@ Print ""abc"" as number
             using (var test = new ScriptTest(@"Print true as vector")) {
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Cannot convert boolean True to vector", test.Logger[1]);
             }
         }
@@ -621,7 +621,7 @@ Print ""abc"" as number
             {
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Cannot convert number 1 to vector", test.Logger[1]);
             }
         }
@@ -637,7 +637,7 @@ Print ""abc"" as vector
                 test.RunOnce();
 
                 Assert.AreEqual("0:0:7", test.Logger[0]);
-                Assert.AreEqual("Exception Occurred:", test.Logger[1]);
+                Assert.AreEqual("System Exception Occurred:", test.Logger[1]);
 
             }
         }
@@ -676,7 +676,7 @@ Print ""abc"" as vector
             using (var test = new ScriptTest(@"Print [0, 1, 2] as vector")) {
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Cannot convert list [0,1,2] to vector", test.Logger[1]);
             }
         }
@@ -688,7 +688,7 @@ Print ""abc"" as vector
             using (var test = new ScriptTest(@"Print true as color")) {
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Cannot convert boolean True to color", test.Logger[1]);
             }
         }
@@ -756,7 +756,7 @@ Print -128:128:356 as color
             using (var test = new ScriptTest(@"Print [0, 1, 2] as color")) {
                 test.RunOnce();
 
-                Assert.AreEqual("Exception Occurred:", test.Logger[0]);
+                Assert.AreEqual("Runtime Exception Occurred:", test.Logger[0]);
                 Assert.AreEqual("Cannot convert list [0,1,2] to color", test.Logger[1]);
             }
         }

--- a/EasyCommands.Tests/TokenizeTests/BlueprintParsingTests.cs
+++ b/EasyCommands.Tests/TokenizeTests/BlueprintParsingTests.cs
@@ -1,14 +1,14 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using Sandbox.Common.ObjectBuilders.Definitions;
-using Malware.MDKUtilities;
 using IngameScript;
 using static EasyCommands.Tests.ScriptTests.MockEntityUtility;
+using static EasyCommands.Tests.ParameterParsingTests.ParsingTestUtility;
 
 namespace EasyCommands.Tests.TokenizeTests {
     [TestClass]
     public class BlueprintParsingTests : ForceLocale {
-        Program program = MDKFactory.CreateProgram<Program>();
+        Program program = CreateProgram();
 
         [TestInitialize]
         public void testInit() {

--- a/EasyCommands.Tests/TokenizeTests/BracketTests.cs
+++ b/EasyCommands.Tests/TokenizeTests/BracketTests.cs
@@ -1,15 +1,15 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using Malware.MDKUtilities;
 using IngameScript;
 using static IngameScript.Program;
+using static EasyCommands.Tests.ParameterParsingTests.ParsingTestUtility;
 
 namespace EasyCommands.Tests.TokenizeTests {
     [TestClass]
     public class BracketTests : ForceLocale {
         [TestMethod]
         public void TestBasicBrackets() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("test [ string ]");
             Assert.AreEqual(4, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
@@ -20,7 +20,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void TestBracketsMissingSpaces() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("test [string] there");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
@@ -32,7 +32,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void TestInlineBrackets() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("test list[string] there");
             Assert.AreEqual(6, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
@@ -45,7 +45,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void TestMultiInlineBrackets() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("test list[string1][string2] there");
             Assert.AreEqual(9, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
@@ -61,7 +61,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void TestCommaSeparatedInlineBrackets() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("test list[string1,string2] there");
             Assert.AreEqual(8, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
@@ -76,7 +76,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void TestMissingSpaceEmptyBrackets() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("test list[] there");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
@@ -88,7 +88,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void TestMissingSpaceBeforeOpeningBracket() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("test [string ]there");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
@@ -100,7 +100,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void TestMissingSpaceAfterClosingBracket() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("test[ string ] there");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
@@ -112,7 +112,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void TestEmbeddedBracketsMissingSpaces() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("test [[string] there]");
             Assert.AreEqual(7, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);

--- a/EasyCommands.Tests/TokenizeTests/FloatingPointTests.cs
+++ b/EasyCommands.Tests/TokenizeTests/FloatingPointTests.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using Malware.MDKUtilities;
 using IngameScript;
+using static EasyCommands.Tests.ParameterParsingTests.ParsingTestUtility;
 
 namespace EasyCommands.Tests.TokenizeTests {
     [TestClass]
@@ -32,7 +32,7 @@ namespace EasyCommands.Tests.TokenizeTests {
         }
 
         void VerifyTokensSplit(string token) {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("assign a to 2.0" + token + ".5");
             Assert.AreEqual(6, tokens.Count);
             Assert.AreEqual("assign", tokens[0].original);

--- a/EasyCommands.Tests/TokenizeTests/ItemParsingTests.cs
+++ b/EasyCommands.Tests/TokenizeTests/ItemParsingTests.cs
@@ -1,14 +1,14 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using Sandbox.Common.ObjectBuilders.Definitions;
-using Malware.MDKUtilities;
 using IngameScript;
 using static EasyCommands.Tests.ScriptTests.MockEntityUtility;
+using static EasyCommands.Tests.ParameterParsingTests.ParsingTestUtility;
 
 namespace EasyCommands.Tests.TokenizeTests {
     [TestClass]
     public class ItemParsingTests : ForceLocale {
-        Program program = MDKFactory.CreateProgram<Program>();        
+        Program program = CreateProgram();
 
         [TestMethod]
         public void ParseOres() {

--- a/EasyCommands.Tests/TokenizeTests/ParenthesisTests.cs
+++ b/EasyCommands.Tests/TokenizeTests/ParenthesisTests.cs
@@ -1,15 +1,15 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using Malware.MDKUtilities;
 using IngameScript;
 using static IngameScript.Program;
+using static EasyCommands.Tests.ParameterParsingTests.ParsingTestUtility;
 
 namespace EasyCommands.Tests.TokenizeTests {
     [TestClass]
     public class ParenthesisTests : ForceLocale {
         [TestMethod]
         public void TestBasicParenthesis() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("test ( string )");
             Assert.AreEqual(4, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
@@ -20,7 +20,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void TestParenthesesMissingSpaces() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("test (string) there");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
@@ -32,7 +32,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void TestMissingSpaceBeforeOpeningParenthesis() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("test (string )there");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
@@ -44,7 +44,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void TestMissingSpaceAfterClosingParenthesis() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("test( string ) there");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);
@@ -56,7 +56,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void TestEmbeddedParenthesesMissingSpaces() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("test ((string) there)");
             Assert.AreEqual(7, tokens.Count);
             Assert.AreEqual("test", tokens[0].original);

--- a/EasyCommands.Tests/TokenizeTests/StringTests.cs
+++ b/EasyCommands.Tests/TokenizeTests/StringTests.cs
@@ -1,15 +1,15 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using Malware.MDKUtilities;
 using IngameScript;
 using static IngameScript.Program;
+using static EasyCommands.Tests.ParameterParsingTests.ParsingTestUtility;
 
 namespace EasyCommands.Tests.TokenizeTests {
     [TestClass]
     public class StringTests : ForceLocale {
         [TestMethod]
         public void BasicStrings() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("turn on the rotors");
             Assert.AreEqual(4, tokens.Count);
             Assert.AreEqual("turn", tokens[0].original);
@@ -20,7 +20,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void StringWithDoubleQuotes() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("turn on the \"test rotors\"");
             Assert.AreEqual(4, tokens.Count);
             Assert.AreEqual("turn", tokens[0].original);
@@ -31,7 +31,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void MultipleDoubleQuotes() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("tell the \"test program\" to \"run gotoTest\"");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("tell", tokens[0].original);
@@ -43,7 +43,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void SingleQuotes() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("tell the program to 'run gotoTest'");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("tell", tokens[0].original);
@@ -55,7 +55,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void MultipleSingleQuotes() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("tell the 'test program' to 'run gotoTest'");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("tell", tokens[0].original);
@@ -67,7 +67,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void SingleQuotesAndDoubleQuotes() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("tell the \"test program\" to 'run gotoTest'");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("tell", tokens[0].original);
@@ -79,7 +79,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void EscapedSingleQuotes() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("print `It's awesome!`");
             Assert.AreEqual(2, tokens.Count);
             Assert.AreEqual("print", tokens[0].original);
@@ -88,7 +88,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void DoubleQuotesInsideSingleQuotes() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("tell the \"test program\" to 'run \"goto testFunction\"'");
             Assert.AreEqual(5, tokens.Count);
             Assert.AreEqual("tell", tokens[0].original);
@@ -124,7 +124,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void SubtractionMissingSpaces() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("assign a to b-c");
             Assert.AreEqual(6, tokens.Count);
             Assert.AreEqual("assign", tokens[0].original);
@@ -137,7 +137,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void NegativeNumbersAreLeftAlone() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("assign a to -3");
             Assert.AreEqual(4, tokens.Count);
             Assert.AreEqual("assign", tokens[0].original);
@@ -148,7 +148,7 @@ namespace EasyCommands.Tests.TokenizeTests {
 
         [TestMethod]
         public void VectorsAreLeftAlone() {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("assign a to -345.34:-3452.34:-35343.345");
             Assert.AreEqual(4, tokens.Count);
             Assert.AreEqual("assign", tokens[0].original);
@@ -158,7 +158,7 @@ namespace EasyCommands.Tests.TokenizeTests {
         }
 
         void VerifyTokensSplit(string token) {
-            var program = MDKFactory.CreateProgram<Program>();
+            var program = CreateProgram();
             var tokens = program.Tokenize("assign a to b" + token + "c");
             Assert.AreEqual(6, tokens.Count);
             Assert.AreEqual("assign", tokens[0].original);

--- a/EasyCommands/BlockHandlers/AntennaBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/AntennaBlockHandlers.cs
@@ -21,7 +21,7 @@ namespace IngameScript {
     partial class Program {
         public class LaserAntennaBlockHandler : FunctionalBlockHandler<IMyLaserAntenna> {
             public LaserAntennaBlockHandler() {
-                AddVectorHandler(Property.TARGET, b => b.TargetCoords, (b, v) => b.SetTargetCoords("GPS:Target:" + VectorToString(v) + ":"));
+                AddVectorHandler(Property.TARGET, b => b.TargetCoords, (b, v) => b.SetTargetCoords($"GPS:Target:{VectorToString(v)}:"));
                 AddBooleanHandler(Property.LOCKED, b => b.IsPermanent, (b,v) => b.IsPermanent = v);
                 var rangeHandler = NumericHandler(b => b.Range, (b, v) => b.Range = v, 1000);
                 AddPropertyHandler(Property.RANGE, rangeHandler);

--- a/EasyCommands/BlockHandlers/AssemblerBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/AssemblerBlockHandlers.cs
@@ -62,7 +62,7 @@ namespace IngameScript {
                 float amount = GetRequestedAmount(p);
                 foreach(MyDefinitionId bp in PROGRAM.GetItemBluePrints(GetRequestedItemFilter(p))) {
                     try { b.AddQueueItem(bp, (MyFixedPoint)amount); } catch (Exception) {
-                        throw new Exception("Unknown BlueprintId: " + bp.SubtypeId);
+                        throw new RuntimeException("Unknown BlueprintId: " + bp.SubtypeId);
                     }
                 }
             }

--- a/EasyCommands/BlockHandlers/BlockHandlerRegistry.cs
+++ b/EasyCommands/BlockHandlers/BlockHandlerRegistry.cs
@@ -84,7 +84,7 @@ namespace IngameScript {
             };
 
             public static IBlockHandler GetBlockHandler(Block blockType) {
-                if (!blockHandlers.ContainsKey(blockType)) throw new Exception("Unsupported Block Type: " + blockType);
+                if (!blockHandlers.ContainsKey(blockType)) throw new RuntimeException("Unsupported Block Type: " + blockType);
                 return blockHandlers[blockType];
             }
 

--- a/EasyCommands/BlockHandlers/BlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/BlockHandlers.cs
@@ -111,7 +111,7 @@ namespace IngameScript {
 
             public virtual PropertyHandler<T> GetPropertyHandler(PropertySupplier property) {
                 if (propertyHandlers.ContainsKey(property.propertyType)) return propertyHandlers[property.propertyType];
-                throw new Exception(typeof(T).Name + " does not have property: " + (property.propertyWord ?? property.propertyType));
+                throw new RuntimeException(typeof(T).Name + " does not have property: " + (property.propertyWord ?? property.propertyType));
             }
 
             public List<Object> SelectBlocks<U>(List<U> blocks, Func<U, bool> selector = null) where U : IMyTerminalBlock =>

--- a/EasyCommands/BlockHandlers/RotorBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/RotorBlockHandlers.cs
@@ -61,7 +61,7 @@ namespace IngameScript {
 
         static void RotateToValue(IMyMotorStator rotor, Primitive primitive) {
             if(primitive.returnType!=Return.NUMERIC) {
-                throw new Exception("Cannot rotate rotor to non-numeric value: " + primitive);
+                throw new RuntimeException("Cannot rotate rotor to non-numeric value: " + primitive);
             }
 
             float value = CastNumber(primitive);
@@ -79,7 +79,7 @@ namespace IngameScript {
 
         static void RotateToValue(IMyMotorStator rotor, Primitive primitive, Direction direction) {
             if (primitive.returnType != Return.NUMERIC) {
-                throw new Exception("Cannot rotate rotor to non-numeric value: " + primitive);
+                throw new RuntimeException("Cannot rotate rotor to non-numeric value: " + primitive);
             }
 
             float value = GetCorrectedAngle(CastNumber(primitive));

--- a/EasyCommands/BlockHandlers/TerminalBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/TerminalBlockHandlers.cs
@@ -52,7 +52,7 @@ namespace IngameScript {
             PROGRAM.propertyCache.GetOrCreate(block.GetType(), propertySupplier.propertyType, s => {
                 var property = block.GetProperty(s);
                 if (property == null)
-                    throw new Exception(block.BlockDefinition.SubtypeName + " does not have property: " + (propertySupplier.propertyWord ?? s));
+                    throw new RuntimeException(block.BlockDefinition.SubtypeName + " does not have property: " + (propertySupplier.propertyWord ?? s));
                 return property;
         });
 
@@ -98,7 +98,7 @@ namespace IngameScript {
             public override PropertyHandler<T> GetPropertyHandler(PropertySupplier property) {
                 try {
                     return base.GetPropertyHandler(property);
-                } catch (Exception) {
+                } catch (RuntimeException) {
                     return new TerminalPropertyHandler<T>(property, ResolvePrimitive(1));
                 }
             }
@@ -149,7 +149,7 @@ namespace IngameScript {
                 base.SelectBlocksByType(blocks, selector).Where(SubType);
         }
 
-        public static Func<IMyFunctionalBlock, bool> IsSubType(string subType) => 
+        public static Func<IMyFunctionalBlock, bool> IsSubType(string subType) =>
             b => subType.Length == 0 || b.BlockDefinition.SubtypeId.Contains(subType);
 
         /// <summary>

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -461,7 +461,7 @@ namespace IngameScript {
 
         IEnumerable<String> SeperatorPass(String command, string[] separators, Pass nextPass = null) {
             var newCommand = command;
-            foreach (var s in separators) newCommand = newCommand.Replace(s, " " + s + " ");
+            foreach (var s in separators) newCommand = newCommand.Replace(s, $" {s} ");
             return newCommand
                 .Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)
                 .SelectMany(token => separators.Contains(token) || nextPass == null ? Once(token) : nextPass(token));

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -301,7 +301,7 @@ namespace IngameScript {
             });
             AddControlWords(Words("return"), thread => {
                 FunctionCommand currentFunction = thread.GetCurrentCommand<FunctionCommand>(command => true);
-                if (currentFunction == null) throw new Exception("Invalid use of return command");
+                if (currentFunction == null) throw new RuntimeException("Invalid use of return command");
                 currentFunction.function = new NullCommand();
                 return false;
             });

--- a/EasyCommands/CommandParsers/ParameterProcessors.cs
+++ b/EasyCommands/CommandParsers/ParameterProcessors.cs
@@ -63,7 +63,7 @@ namespace IngameScript {
                         return true;
                     }
                 }
-                throw new Exception("Missing Closing Parenthesis for Command");
+                throw new ParserException("Missing Closing Parenthesis for Command");
             }
         }
 
@@ -85,7 +85,7 @@ namespace IngameScript {
                         return true;
                     }
                 }
-                throw new Exception("Missing Closing Bracket for List");
+                throw new ParserException("Missing Closing Bracket for List");
             }
 
             IVariable ParseVariable(List<ICommandParameter> p, int startIndex, int endIndex) {

--- a/EasyCommands/CommandParsers/ParsingEngine.cs
+++ b/EasyCommands/CommandParsers/ParsingEngine.cs
@@ -159,7 +159,7 @@ namespace IngameScript {
         Command ParseCommand(List<ICommandParameter> parameters, int lineNumber) {
             CommandReferenceParameter command = ParseParameters<CommandReferenceParameter>(parameters);
 
-            if (command == null) throw new Exception("Unable to parse command from command parameters at line number: " + lineNumber);
+            if (command == null) throw new ParserException("Unable to parse command from command parameters at line number: " + lineNumber);
             return command.value;
         }
 

--- a/EasyCommands/Commands/Commands.cs
+++ b/EasyCommands/Commands/Commands.cs
@@ -19,15 +19,6 @@ using VRageMath;
 
 namespace IngameScript {
     partial class Program {
-
-        public class InterruptException : Exception {
-            public ProgramState ProgramState;
-
-            public InterruptException(ProgramState programState) {
-                ProgramState = programState;
-            }
-        }
-
         public interface IInterruptableCommand {
             void Break();
             void Continue();
@@ -100,9 +91,9 @@ namespace IngameScript {
                 if (function == null) {
                     var name = functionName();
                     FunctionDefinition definition;
-                    if (!PROGRAM.functions.TryGetValue(name, out definition)) throw new Exception("Invalid Function Name: " + name);
+                    if (!PROGRAM.functions.TryGetValue(name, out definition)) throw new RuntimeException("Invalid Function Name: " + name);
                     var parameterCount = definition.parameterNames.Count;
-                    if (inputParameters.Count != parameterCount) throw new Exception("Function " + name + " expects " + parameterCount + " parameters");
+                    if (inputParameters.Count != parameterCount) throw new RuntimeException($"Function {name} expects {parameterCount} parameters");
 
                     function = definition.function.Clone();
 
@@ -193,7 +184,7 @@ namespace IngameScript {
 
         public IInterruptableCommand GetInterrupableCommand(string controlStatement) {
             IInterruptableCommand breakCommand = GetCurrentThread().GetCurrentCommand<IInterruptableCommand>(command => (command as ConditionalCommand)?.alwaysEvaluate ?? true);
-            if (breakCommand == null) throw new Exception("Invalid use of " + controlStatement + " command");
+            if (breakCommand == null) throw new RuntimeException($"Invalid use of {controlStatement} command");
             return breakCommand;
         }
 
@@ -286,7 +277,7 @@ namespace IngameScript {
             }
 
             public override bool Execute() {
-                if (from.GetBlockType() != Block.CARGO || to.GetBlockType() != Block.CARGO) throw new Exception("Transfers can only be executed on cargo block types");
+                if (from.GetBlockType() != Block.CARGO || to.GetBlockType() != Block.CARGO) throw new RuntimeException("Transfers can only be executed on cargo block types");
 
                 var filter = PROGRAM.AnyItem(PROGRAM.GetItemFilters(CastString((second ?? first).GetValue())));
                 var items = NewList<MyInventoryItem>();

--- a/EasyCommands/Commands/Selectors.cs
+++ b/EasyCommands/Commands/Selectors.cs
@@ -94,7 +94,7 @@ namespace IngameScript {
                 var parameters = PROGRAM.ParseCommandParameters(PROGRAM.Tokenize(selector));
                 var blockType = findLast<BlockTypeCommandParameter>(parameters);
                 isGroup = findLast<GroupCommandParameter>(parameters) != null;
-                if (blockType == null) throw new Exception("Cannot parse block type from selector: " + selector);
+                if (blockType == null) throw new RuntimeException("Cannot parse block type from selector: " + selector);
                 return blockType.value;
             }
         }

--- a/EasyCommands/Common/Collections.cs
+++ b/EasyCommands/Common/Collections.cs
@@ -40,7 +40,7 @@ namespace IngameScript {
                             .DefaultIfEmpty(EmptyList())
                             .First();
                     default:
-                        throw new Exception("Cannot lookup collection value for value: " + key.value);
+                        throw new RuntimeException("Cannot lookup collection value for value: " + key.value);
                 }
             }
 
@@ -55,7 +55,7 @@ namespace IngameScript {
                         keyedValues.Add(new KeyedVariable(GetStaticVariable(keyString), value));
                     else
                         existing.Value = value;
-                } else throw new Exception("Cannot set collection value by value: " + key.value);
+                } else throw new RuntimeException("Cannot set collection value by value: " + key.value);
             }
 
             public KeyedList Combine(KeyedList other) {

--- a/EasyCommands/Common/Collections.cs
+++ b/EasyCommands/Common/Collections.cs
@@ -73,7 +73,7 @@ namespace IngameScript {
             public KeyedList Keys() => NewKeyedList(keyedValues.Where(v => v.HasKey()).Select(v => GetStaticVariable(v.GetKey())));
             public KeyedList Values() => NewKeyedList(keyedValues.Select(v => v.Value));
             public KeyedList DeepCopy() => NewKeyedList(keyedValues.Select(k => k.DeepCopy()));
-            public String Print() => "[" + string.Join(",", keyedValues.Select(k => k.Print())) + "]";
+            public String Print() => $"[{string.Join(",", keyedValues.Select(k => k.Print()))}]";
         }
     }
 }

--- a/EasyCommands/Common/Exceptions.cs
+++ b/EasyCommands/Common/Exceptions.cs
@@ -5,7 +5,6 @@ using SpaceEngineers.Game.ModAPI.Ingame;
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using VRage;

--- a/EasyCommands/Common/Exceptions.cs
+++ b/EasyCommands/Common/Exceptions.cs
@@ -1,0 +1,39 @@
+﻿using Sandbox.Game.EntityComponents;
+using Sandbox.ModAPI.Ingame;
+using Sandbox.ModAPI.Interfaces;
+using SpaceEngineers.Game.ModAPI.Ingame;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using VRage;
+using VRage.Collections;
+using VRage.Game;
+using VRage.Game.Components;
+using VRage.Game.GUI.TextPanel;
+using VRage.Game.ModAPI.Ingame;
+using VRage.Game.ModAPI.Ingame.Utilities;
+using VRage.Game.ObjectBuilders.Definitions;
+using VRageMath;
+
+namespace IngameScript {
+    partial class Program {
+        public class InterruptException : Exception {
+            public ProgramState ProgramState;
+
+            public InterruptException(ProgramState programState) {
+                ProgramState = programState;
+            }
+        }
+
+        public class ParserException : Exception {
+            public ParserException(string msg) : base(msg) { }
+        }
+
+        public class RuntimeException : Exception {
+            public RuntimeException(string msg) : base(msg) { }
+        }
+    }
+}

--- a/EasyCommands/Common/Operations.cs
+++ b/EasyCommands/Common/Operations.cs
@@ -32,7 +32,7 @@ namespace IngameScript {
 
         public static Primitive PerformOperation(BiOperand type, Primitive a, Primitive b) =>
             PROGRAM.BiOperations.GetValueOrDefault(MyTuple.Create(type, a.returnType, b.returnType), (p, q) => {
-                throw new Exception($"Cannot perform operation: {biOperandToString[type]} on types: {returnToString[p.returnType]}, {returnToString[q.returnType]}");
+                throw new RuntimeException($"Cannot perform operation: {biOperandToString[type]} on types: {returnToString[p.returnType]}, {returnToString[q.returnType]}");
             })(a, b);
 
         void AddUniOperation<T>(UniOperand type, Func<T,object> resolver) {

--- a/EasyCommands/Common/Operations.cs
+++ b/EasyCommands/Common/Operations.cs
@@ -27,12 +27,12 @@ namespace IngameScript {
 
         public static Primitive PerformOperation(UniOperand type, Primitive a) =>
             PROGRAM.UniOperations.GetValueOrDefault(MyTuple.Create(type, a.returnType), p => {
-                throw new Exception("Cannot perform operation: " + uniOperandToString[type] + " on type: " + returnToString[p.returnType]);
+                throw new RuntimeException($"Cannot perform operation: {uniOperandToString[type]} on type: {returnToString[p.returnType]}");
             })(a);
 
         public static Primitive PerformOperation(BiOperand type, Primitive a, Primitive b) =>
             PROGRAM.BiOperations.GetValueOrDefault(MyTuple.Create(type, a.returnType, b.returnType), (p, q) => {
-                throw new Exception("Cannot perform operation: " + biOperandToString[type] + " on types: " + returnToString[p.returnType] + ", " + returnToString[q.returnType]);
+                throw new Exception($"Cannot perform operation: {biOperandToString[type]} on types: {returnToString[p.returnType]}, {returnToString[q.returnType]}");
             })(a, b);
 
         void AddUniOperation<T>(UniOperand type, Func<T,object> resolver) {

--- a/EasyCommands/Common/Primitives.cs
+++ b/EasyCommands/Common/Primitives.cs
@@ -40,7 +40,7 @@ namespace IngameScript {
 
         delegate Object Converter(Primitive p);
         static KeyValuePair<T, Converter> CastFunction<T>(T r, Converter func) => KeyValuePair(r, func);
-        static Converter Failure(Return returnType) => p => { throw new Exception("Cannot convert " + returnToString[p.returnType] + " " + CastString(p) + " to " + returnToString[returnType]); };
+        static Converter Failure(Return returnType) => p => { throw new RuntimeException($"Cannot convert {returnToString[p.returnType]} {CastString(p)} to {returnToString[returnType]}"); };
 
         static Dictionary<Type, Dictionary<Return, Converter>> castFunctions = NewDictionary(
             KeyValuePair(typeof(bool), NewDictionary(

--- a/EasyCommands/Common/Variables.cs
+++ b/EasyCommands/Common/Variables.cs
@@ -57,7 +57,7 @@ namespace IngameScript {
             public Primitive GetValue() {
                 if (NewList(X, Y, Z).All(v => v.GetValue().returnType == Return.NUMERIC))
                     return ResolvePrimitive(Vector(CastNumber(X.GetValue()), CastNumber(Y.GetValue()), CastNumber(Z.GetValue())));
-                throw new Exception("Invalid Variable in Vector");
+                throw new RuntimeException("Invalid Variable in Vector");
             }
         }
 
@@ -127,7 +127,7 @@ namespace IngameScript {
                 case AggregationMode.ALL: return count > 0 && matches == count;
                 case AggregationMode.ANY: return matches > 0;
                 case AggregationMode.NONE: return matches == 0;
-                default: throw new Exception("Unsupported Aggregation Mode");
+                default: throw new RuntimeException("Unsupported Aggregation Mode");
             }
         }
 
@@ -159,7 +159,7 @@ namespace IngameScript {
             public Primitive GetValue() {
                 try {
                     return PROGRAM.GetVariable(value).GetValue();
-                } catch(Exception) {
+                } catch(RuntimeException) {
                     return ResolvePrimitive(value);
                 }
             }

--- a/EasyCommands/Common/Variables.cs
+++ b/EasyCommands/Common/Variables.cs
@@ -159,7 +159,7 @@ namespace IngameScript {
             public Primitive GetValue() {
                 try {
                     return PROGRAM.GetVariable(value).GetValue();
-                } catch(RuntimeException) {
+                } catch(Exception) {
                     return ResolvePrimitive(value);
                 }
             }

--- a/EasyCommands/Common/Variables.cs
+++ b/EasyCommands/Common/Variables.cs
@@ -238,7 +238,7 @@ namespace IngameScript {
 
             public KeyedVariable DeepCopy() => new KeyedVariable(Key == null ? null : GetStaticVariable(Key.GetValue().DeepCopy().value), GetStaticVariable(Value.GetValue().DeepCopy().value));
 
-            String Wrap(String value) => value.Contains(" ") ? "\"" + value + "\"" : value;
+            String Wrap(String value) => value.Contains(" ") ? $"\"{value}\"" : value;
 
             public bool Equals(KeyedVariable variable) => GetKey() == variable.GetKey() && GetValue().value.Equals(variable.GetValue().value);
             public int CompareTo(KeyedVariable other) => GetValue().CompareTo(other.GetValue());

--- a/EasyCommands/EasyCommands.csproj
+++ b/EasyCommands/EasyCommands.csproj
@@ -175,6 +175,7 @@
     <Compile Include="Commands\Selectors.cs" />
     <Compile Include="Common\Aggregators.cs" />
     <Compile Include="Common\Cache.cs" />
+    <Compile Include="Common\Exceptions.cs" />
     <Compile Include="Common\Collections.cs" />
     <Compile Include="Common\Items.cs" />
     <Compile Include="Common\Operations.cs" />

--- a/EasyCommands/Program.cs
+++ b/EasyCommands/Program.cs
@@ -151,7 +151,7 @@ namespace IngameScript {
                 Info(stateTuple.Key);
                 Runtime.UpdateFrequency = stateTuple.Value ? updateFrequency : UpdateFrequency.None;
             } catch (Exception e) {
-                Print($"{(e is ParserException ? "Parser Exception" : e is RuntimeException ? "Runtime Exception" : "System Exception")} Occured:");
+                Print($"{(e is ParserException ? "Parser Exception" : e is RuntimeException ? "Runtime Exception" : "System Exception")} Occurred:");
                 Print(e.Message);
                 Runtime.UpdateFrequency = UpdateFrequency.None;
                 return;

--- a/EasyCommands/Program.cs
+++ b/EasyCommands/Program.cs
@@ -224,7 +224,7 @@ namespace IngameScript {
                 name = n;
             }
 
-            public String GetName() => "[" + prefix + "] " + name;
+            public String GetName() => $"[{prefix}] {name}";
             public void SetName(String s) => name = s;
         }
 

--- a/EasyCommands/Program.cs
+++ b/EasyCommands/Program.cs
@@ -85,12 +85,12 @@ namespace IngameScript {
 
         public void QueueThread(Thread thread) {
             threadQueue.Add(thread);
-            if (threadQueue.Count > maxQueuedThreads) throw new Exception("Stack Overflow Exception! Cannot have more than " + maxQueuedThreads + " queued commands");
+            if (threadQueue.Count > maxQueuedThreads) throw new RuntimeException($"Cannot have more than {maxQueuedThreads} queued commands");
         }
 
         public void QueueAsyncThread(Thread thread) {
             asyncThreadQueue.Add(thread);
-            if (asyncThreadQueue.Count > maxAsyncThreads) throw new Exception("Stack Overflow Exception! Cannot have more than " + maxAsyncThreads + "concurrent async commands");
+            if (asyncThreadQueue.Count > maxAsyncThreads) throw new RuntimeException($"Cannot have more than {maxAsyncThreads} concurrent async commands");
         }
 
         public void SetGlobalVariable(String variableName, IVariable variable) {
@@ -104,7 +104,7 @@ namespace IngameScript {
             } else if (globalVariables.ContainsKey(variableName)) {
                 return globalVariables[variableName];
             } else {
-                throw new Exception("No Variable Exists for name: " + variableName);
+                throw new RuntimeException("No Variable Exists for name: " + variableName);
             }
         }
 


### PR DESCRIPTION
only set `PROGRAM` during the constructor and `Main()` and make sure it is unset in a `finally` block. 
_This is necessary since static variables inside the script class are leaked. In our case this means `PROGRAM` kept the whole script and potentially cached blocks from being garbage collected._

The tests not using the `ScriptTest` mechanism are adapted to set `PROGRAM` appropriately.
also includes changed exceptions and some additional char savings. 