### PR TITLE
[Bugfix] Function Request For Updated Request

### DIFF
--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Commands/SimpleCommandExecutionTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Commands/SimpleCommandExecutionTests.cs
@@ -219,5 +219,36 @@ print myValue";
                 Assert.AreEqual("myValue", test.Logger[0]);
             }
         }
+
+        [TestMethod]
+        public void updatedScriptRunsRequestedFunctionUponCompletion() {
+            String script = @"
+:main
+print ""Hello""
+";
+
+            String newScript = @"
+:main
+wait 1
+
+:myFunction
+print ""Hello World!""
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.program.commandParseAmount = 1;
+                test.RunUntilDone();
+                Assert.AreEqual(1, test.Logger.Count);
+                Assert.AreEqual("Hello", test.Logger[0]);
+
+                test.SetScript(newScript);
+                test.Logger.Clear();
+                test.RunWithArgument("myFunction");
+                test.RunUntilDone();
+
+                Assert.AreEqual(1, test.Logger.Count);
+                Assert.AreEqual("Hello World!", test.Logger[0]);
+            }
+        }
     }
 }

--- a/EasyCommands/Program.cs
+++ b/EasyCommands/Program.cs
@@ -132,6 +132,8 @@ namespace IngameScript {
 
                 if (!ParseCommands()) {
                     Runtime.UpdateFrequency = updateFrequency;
+                    state = ProgramState.RUNNING;
+                    QueueRequest(argument);
                     return;
                 }
 
@@ -142,7 +144,7 @@ namespace IngameScript {
                     var messageCommands = messages.Select(message => new Thread(ParseCommand((String)message.Data), "Message", message.Tag));
                     threadQueue.InsertRange(0, messageCommands);
                 }
-                if (!String.IsNullOrEmpty(argument)) { threadQueue.Insert(0, new Thread(ParseCommand(argument), "Request", argument)); }
+                QueueRequest(argument);
 
                 RunThreads();
 
@@ -207,6 +209,10 @@ namespace IngameScript {
             } catch(InterruptException interrupt) {
                 state = interrupt.ProgramState;
             }
+        }
+
+        public void QueueRequest(String argument) {
+            if (!String.IsNullOrEmpty(argument)) threadQueue.Insert(0, new Thread(ParseCommand(argument), "Request", argument));
         }
 
         public class Thread {


### PR DESCRIPTION
Fixed issue where requesting a specific function to be executed after re-parsing did not work correctly.  Previously the main function would be executed after parsing completed, regardless of whether the user initiated a re-parsing of the script by changing the script on a non-running program, and then requested a specific function to run (either by a button click or manually requesting from the terminal menu).