### PR TITLE
Changed Return to End Thread When Outside Function Call

### DIFF
--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -301,8 +301,9 @@ namespace IngameScript {
             });
             AddControlWords(Words("return"), thread => {
                 FunctionCommand currentFunction = thread.GetCurrentCommand<FunctionCommand>(command => true);
-                if (currentFunction == null) throw new RuntimeException("Invalid use of return command");
-                currentFunction.function = new NullCommand();
+                Command nullCommand = new NullCommand();
+                if (currentFunction == null) thread.Command = nullCommand;
+                else currentFunction.function = nullCommand;
                 return false;
             });
 


### PR DESCRIPTION
This commit changes the behavior of return so that if you call it outside of a function, it terminates the current thread instead of throwing an exception.