### PR TITLE
Fix selector parsing bugs

### DIFF
--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Primitives/SimpleListTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Primitives/SimpleListTests.cs
@@ -279,6 +279,23 @@ Print ""After: "" + myList
         }
 
         [TestMethod]
+        public void AssignListIndexStringValueContainingSelectorName() {
+            String script = @"
+:main
+assign myList to [1,2,3,4]
+Print ""Before: "" + myList
+assign myList[0] to ""My Drill""
+Print ""After: "" + myList
+";
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("Before: [1,2,3,4]"));
+                Assert.IsTrue(test.Logger.Contains("After: [\"My Drill\",2,3,4]"));
+            }
+        }
+
+        [TestMethod]
         public void AssignListIndexNewValueFromExpression() {
             String script = @"
 :main

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Selectors/SimpleSelectorTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Selectors/SimpleSelectorTests.cs
@@ -71,6 +71,20 @@ namespace EasyCommands.Tests.ScriptTests {
         }
 
         [TestMethod]
+        public void BasicImpliedSelectorWithExplicitGroup() {
+            using (var test = new ScriptTest(@"turn on the ""test piston"" group")) {
+                var mockPiston1 = new Mock<IMyPistonBase>();
+                var mockPiston2 = new Mock<IMyPistonBase>();
+                test.MockBlocksInGroup("test piston", mockPiston1, mockPiston2);
+
+                test.RunOnce();
+
+                mockPiston1.VerifySet(p => p.Enabled = true);
+                mockPiston2.VerifySet(p => p.Enabled = true);
+            }
+        }
+
+        [TestMethod]
         public void AllSelector() {
             using (var test = new ScriptTest(@"turn on all the pistons")) {
                 var mockPiston1 = new Mock<IMyPistonBase>();
@@ -545,5 +559,28 @@ set myVariable to 1
             }
         }
 
+        [TestMethod]
+        public void SetExplicitSelectorPropertyValueToStringPropertyContainingSelectorName() {
+            using (var test = new ScriptTest(@"set ""test lighthouse"" beacon text to ""My Beacon Text""")) {
+                var mockBeacon = new Mock<IMyBeacon>();
+                test.MockBlocksOfType("test lighthouse", mockBeacon);
+
+                test.RunUntilDone();
+
+                mockBeacon.VerifySet(p => p.HudText = "My Beacon Text");
+            }
+        }
+
+        [TestMethod]
+        public void SetImplicitSelectorPropertyValueToStringPropertyContainingSelectorName() {
+            using (var test = new ScriptTest(@"set ""test beacon"" text to ""My Beacon Text""")) {
+                var mockBeacon = new Mock<IMyBeacon>();
+                test.MockBlocksOfType("test beacon", mockBeacon);
+
+                test.RunUntilDone();
+
+                mockBeacon.VerifySet(p => p.HudText = "My Beacon Text");
+            }
+        }
     }
 }

--- a/EasyCommands/CommandParsers/ProcessingEngine.cs
+++ b/EasyCommands/CommandParsers/ProcessingEngine.cs
@@ -64,6 +64,9 @@ namespace IngameScript {
             OneValueRule(Type<ListCommandParameter>, requiredLeft<VariableCommandParameter>(),
                 (list, variable) => new ListIndexCommandParameter(new ListIndexVariable(variable.value, list.value))),
 
+            OneValueRule(Type<ListIndexCommandParameter>, requiredLeft<AssignmentCommandParameter>(),
+                (index, assignment) => new ListIndexAssignmentCommandParameter(index.value, assignment.value)),
+
             //SelfSelectorProcessor
             TwoValueRule(Type<SelfCommandParameter>, optionalRight<BlockTypeCommandParameter>(), optionalRight<GroupCommandParameter>(),
                 (p, blockType, group) => new SelectorCommandParameter(new SelfSelector(blockType?.value))),
@@ -298,9 +301,8 @@ namespace IngameScript {
             NoValueRule(Type<RelativeCommandParameter>, b => NewList<ICommandParameter>()),
 
             //ListIndexAssignmentProcessor
-            TwoValueRule(Type<AssignmentCommandParameter>, requiredRight<VariableCommandParameter>(), requiredRight<VariableCommandParameter>(),
-                (p, list, value) => AllSatisfied(list, value) && list.GetValue().value is ListIndexVariable,
-                (p, list, value) => new CommandReferenceParameter(new ListVariableAssignmentCommand((ListIndexVariable)list.value, value.value, p.value))),
+            OneValueRule(Type<ListIndexAssignmentCommandParameter>, requiredRight<VariableCommandParameter>(),
+                (list, value) => new CommandReferenceParameter(new ListVariableAssignmentCommand(list.listIndex, value.value, list.useReference))),
 
             //PrintCommandProcessor
             OneValueRule(Type<PrintCommandParameter>, requiredRight<VariableCommandParameter>(),

--- a/EasyCommands/Commands/CommandParameters.cs
+++ b/EasyCommands/Commands/CommandParameters.cs
@@ -111,6 +111,16 @@ namespace IngameScript {
             }
         }
 
+        public class ListIndexAssignmentCommandParameter : SimpleCommandParameter {
+            public ListIndexVariable listIndex;
+            public bool useReference;
+
+            public ListIndexAssignmentCommandParameter(ListIndexVariable variable, bool reference) {
+                listIndex = variable;
+                useReference = reference;
+            }
+        }
+
         public class VariableIncrementCommandParameter : ValueCommandParameter<bool> {
             public string variableName;
             public VariableIncrementCommandParameter(string variable, bool increase = true) : base(increase) {

--- a/EasyCommands/Commands/CommandParameters.cs
+++ b/EasyCommands/Commands/CommandParameters.cs
@@ -246,6 +246,11 @@ namespace IngameScript {
             }
         }
 
+        public class AmbiguousSelectorCommandParameter : SelectorCommandParameter { 
+            public AmbiguousSelectorCommandParameter(BlockSelector value) : base(value) {
+            }
+        }
+
         public class BlockTypeCommandParameter : ValueCommandParameter<Block> {
             public BlockTypeCommandParameter(Block value) : base(value) {}
         }


### PR DESCRIPTION
This PR fixes a couple of bugs related to selector parsing, where a string value containing a block type is incorrectly interpreted as a selector, and then the Block Command processor incorrectly interprets the command.

Note that this fix is fairly surgical.  A broader fix is likely needed once multi-property support is added, as a strong association between "which" selector for property values will be needed, which needs to happen before we remove the currently removed "IgnoreCommandParameters"