### PR TITLE
Remove `IgnoreCommandParameter`

### DIFF
--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -67,7 +67,7 @@ namespace IngameScript {
 
         public void InitializeParsers() {
             //Ignored words that have no command parameters
-            AddWords(Words("the", "than", "turned", "block", "panel", "chamber", "drive", "to", "from", "then", "of", "either", "for", "in", "do", "does", "second", "seconds", "be", "being", "digits", "digit"), new IgnoreCommandParameter());
+            AddWords(Words("the", "than", "turned", "block", "panel", "chamber", "drive", "from", "then", "of", "either", "for", "do", "does", "second", "seconds", "be", "being", "digits", "digit"));
 
             //Selector Related Words
             AddWords(Words("blocks", "group", "panels", "chambers", "drives"), new GroupCommandParameter());
@@ -96,6 +96,7 @@ namespace IngameScript {
             AddWords(Words("--", "-="), new IncrementCommandParameter(false));
             AddWords(Words("global"), new GlobalCommandParameter());
             AddWords(Words("by"), new RelativeCommandParameter());
+            AddWords(Words("to"), new AbsoluteCommandParameter());
 
             //Value Words
             AddWords(Words("on", "begin", "true", "start", "started", "resume", "resumed"), new BooleanCommandParameter(true));
@@ -187,6 +188,7 @@ namespace IngameScript {
             AddWords(Words("::"), new TernaryConditionSeparatorParameter());
             AddWords(Words(":"), new ColonSeparatorParameter());
             AddWords(Words("each", "every"), new IteratorCommandParameter());
+            AddWords(Words("in"), new InCommandParameter());
 
             //Conditional Words
             AddWords(Words("if"), new IfCommandParameter(false, false, false));
@@ -428,7 +430,8 @@ namespace IngameScript {
             else //If no property matches, must be a string
                 commandParameters.Add(new AmbiguousStringCommandParameter(token.original, true));
 
-            commandParameters[0].Token = token.original;
+            if (commandParameters.Count > 0)
+                commandParameters[0].Token = token.original;
             return commandParameters;
         }
 

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -420,6 +420,7 @@ namespace IngameScript {
         List<ICommandParameter> ParseCommandParameters(List<Token> tokens) => tokens.SelectMany(ParseCommandParameters).ToList();
 
         List<ICommandParameter> ParseCommandParameters(Token token) {
+            Primitive primitive;
             var commandParameters = NewList<ICommandParameter>();
             if (token.isExplicitString)
                 commandParameters.Add(new VariableCommandParameter(GetStaticVariable(token.original)));
@@ -427,6 +428,8 @@ namespace IngameScript {
                 commandParameters.Add(new AmbiguousStringCommandParameter(token.original, false, ParseCommandParameters(Tokenize(token.token)).ToArray()));
             else if (propertyWords.ContainsKey(token.token))
                 commandParameters.AddList(propertyWords[token.token]);
+            else if (ParsePrimitive(token.original, out primitive))
+                commandParameters.Add(new VariableCommandParameter(GetStaticVariable(primitive.value)));
             else //If no property matches, must be a string
                 commandParameters.Add(new AmbiguousStringCommandParameter(token.original, true));
 

--- a/EasyCommands/CommandParsers/ProcessingEngine.cs
+++ b/EasyCommands/CommandParsers/ProcessingEngine.cs
@@ -50,12 +50,7 @@ namespace IngameScript {
                     name => PROGRAM.functions.ContainsKey(name.value),
                     name => new FunctionDefinitionCommandParameter(() => name.value)),
                 NoValueRule(Type<AmbiguousStringCommandParameter>,
-                    s => {
-                        Primitive primitive;
-                        IVariable variable = s.isImplicit ? new AmbiguousStringVariable(s.value) : GetStaticVariable(s.value);
-                        if (s.isImplicit && ParsePrimitive(s.value, out primitive)) variable = GetStaticVariable(primitive.value);
-                        return new VariableCommandParameter(variable);
-                    })),
+                    s => new VariableCommandParameter(s.isImplicit ? new AmbiguousStringVariable(s.value) : GetStaticVariable(s.value)))),
 
             NoValueRule(Type<AmbiguousCommandParameter>, p => p.alternatives.Count > 0, p => p.alternatives),
 

--- a/EasyCommands/CommandParsers/ProcessingEngine.cs
+++ b/EasyCommands/CommandParsers/ProcessingEngine.cs
@@ -94,7 +94,9 @@ namespace IngameScript {
             OneValueRule(Type<ComparisonCommandParameter>, requiredEither<NotCommandParameter>(),
                 (p, left) => new ComparisonCommandParameter((a, b) => !p.value(a, b))),
             OneValueRule(Type<ComparisonCommandParameter>, requiredRight<ComparisonCommandParameter>(),
-                (p, right) => new ComparisonCommandParameter(right.value)),
+                (p, right) => right),
+            OneValueRule(Type<ComparisonCommandParameter>, requiredRight<AbsoluteCommandParameter>(),
+                (p, to) => p),
 
             //IndexSelectorProcessor
             OneValueRule(Type<IndexSelectorCommandParameter>, requiredLeft<SelectorCommandParameter>(),
@@ -256,10 +258,10 @@ namespace IngameScript {
                 (p, var) => new RepetitionCommandParameter(var.value)),
 
             //TransferCommandProcessor
-            FourValueRule(Type<TransferCommandParameter>, requiredLeft<SelectorCommandParameter>(), requiredRight<SelectorCommandParameter>(), requiredRight<VariableCommandParameter>(), optionalRight<VariableCommandParameter>(),
-                (t, s1, s2, v1, v2) => new CommandReferenceParameter(new TransferItemCommand((t.value ? s1 : s2).value, (t.value ? s2 : s1).value, v1.value, v2?.value))),
-            FourValueRule(Type<TransferCommandParameter>, requiredRight<SelectorCommandParameter>(), requiredRight<SelectorCommandParameter>(), requiredRight<VariableCommandParameter>(), optionalRight<VariableCommandParameter>(),
-                (t, s1, s2, v1, v2) => new CommandReferenceParameter(new TransferItemCommand(s1.value, s2.value, v1.value, v2?.value))),
+            FiveValueRule(Type<TransferCommandParameter>, requiredLeft<SelectorCommandParameter>(), optionalRight<AbsoluteCommandParameter>(), requiredRight<SelectorCommandParameter>(), requiredRight<VariableCommandParameter>(), optionalRight<VariableCommandParameter>(),
+                (t, s1, to, s2, v1, v2) => new CommandReferenceParameter(new TransferItemCommand((t.value ? s1 : s2).value, (t.value ? s2 : s1).value, v1.value, v2?.value))),
+            FiveValueRule(Type<TransferCommandParameter>, requiredRight<SelectorCommandParameter>(), optionalRight<AbsoluteCommandParameter>(), requiredRight<SelectorCommandParameter>(), requiredRight<VariableCommandParameter>(), optionalRight<VariableCommandParameter>(),
+                (t, s1, to, s2, v1, v2) => new CommandReferenceParameter(new TransferItemCommand(s1.value, s2.value, v1.value, v2?.value))),
 
             //Convert Ambiguous Colon to Ternary Condition Separator
             NoValueRule(Type<ColonSeparatorParameter>, b => new TernaryConditionSeparatorParameter()),
@@ -281,9 +283,6 @@ namespace IngameScript {
                 NoValueRule(Type<AmbiguousSelectorCommandParameter>, p => new SelectorCommandParameter(p.value))
             ),
 
-            //AbsoluteCommandParameter
-            NoValueRule(Type<AbsoluteCommandParameter>, p => NewList<ICommandParameter>()),
-
             //AmbiguousSelectorPropertyProcessor
             new BranchingProcessor<SelectorCommandParameter>(
                 BlockCommandProcessor(),
@@ -300,8 +299,8 @@ namespace IngameScript {
                     })),
 
             //ListIndexAssignmentProcessor
-            OneValueRule(Type<ListIndexAssignmentCommandParameter>, requiredRight<VariableCommandParameter>(),
-                (list, value) => new CommandReferenceParameter(new ListVariableAssignmentCommand(list.listIndex, value.value, list.useReference))),
+            TwoValueRule(Type<ListIndexAssignmentCommandParameter>, optionalRight<AbsoluteCommandParameter>(), requiredRight<VariableCommandParameter>(),
+                (list, to, value) => new CommandReferenceParameter(new ListVariableAssignmentCommand(list.listIndex, value.value, list.useReference))),
 
             //PrintCommandProcessor
             OneValueRule(Type<PrintCommandParameter>, requiredRight<VariableCommandParameter>(),
@@ -316,8 +315,8 @@ namespace IngameScript {
                 (p, variables) => new CommandReferenceParameter(new FunctionCommand(p.switchExecution, p.functionDefinition, variables.Select(v => v.value).ToList()))),
 
             //VariableAssignmentProcessor
-            OneValueRule(Type<VariableAssignmentCommandParameter>, requiredRight<VariableCommandParameter>(),
-                (p, var) => new CommandReferenceParameter(new VariableAssignmentCommand(p.variableName, var.value, p.useReference, p.isGlobal))),
+            TwoValueRule(Type<VariableAssignmentCommandParameter>, optionalRight<AbsoluteCommandParameter>(), requiredRight<VariableCommandParameter>(),
+                (p, to, var) => new CommandReferenceParameter(new VariableAssignmentCommand(p.variableName, var.value, p.useReference, p.isGlobal))),
 
             //VariableIncrementProcessor
             TwoValueRule(Type<VariableIncrementCommandParameter>, optionalRight<RelativeCommandParameter>(), optionalRight<VariableCommandParameter>(),
@@ -328,8 +327,8 @@ namespace IngameScript {
 
             //SendCommandProcessor
             //Note: Message to send always comes first: "send <command> to <tag>" is only supported format
-            TwoValueRule(Type<SendCommandParameter>, requiredRight<VariableCommandParameter>(), requiredRight<VariableCommandParameter>(),
-                (p, message, tag) => new CommandReferenceParameter(new SendCommand(message.value, tag.value))),
+            ThreeValueRule(Type<SendCommandParameter>, requiredRight<VariableCommandParameter>(), optionalRight<AbsoluteCommandParameter>(), requiredRight<VariableCommandParameter>(),
+                (p, message, to, tag) => new CommandReferenceParameter(new SendCommand(message.value, tag.value))),
 
             //ListenCommandProcessor
             OneValueRule(Type<ListenCommandParameter>, requiredRight<VariableCommandParameter>(),

--- a/EasyCommands/Commands/CommandParameters.cs
+++ b/EasyCommands/Commands/CommandParameters.cs
@@ -150,6 +150,10 @@ namespace IngameScript {
             }
         }
 
+        public class IdentifierCommandParameter : ValueCommandParameter<String> {
+            public IdentifierCommandParameter(string value) : base(value) { }
+        }
+
         public class BooleanCommandParameter : ValueCommandParameter<bool> {
             public BooleanCommandParameter(bool value) : base(value) {}
         }

--- a/EasyCommands/Commands/CommandParameters.cs
+++ b/EasyCommands/Commands/CommandParameters.cs
@@ -45,7 +45,6 @@ namespace IngameScript {
         public class PrintCommandParameter : SimpleCommandParameter { }
         public class SelfCommandParameter : SimpleCommandParameter { }
         public class GlobalCommandParameter : SimpleCommandParameter { }
-        public class IgnoreCommandParameter : SimpleCommandParameter { }
         public class ThatCommandParameter : SimpleCommandParameter { }
         public class KeyedVariableCommandParameter : SimpleCommandParameter { }
         public class TernaryConditionIndicatorParameter : SimpleCommandParameter { }
@@ -55,6 +54,8 @@ namespace IngameScript {
         public class RoundCommandParameter : SimpleCommandParameter { }
         public class CastCommandParameter : SimpleCommandParameter { }
         public class RelativeCommandParameter : SimpleCommandParameter { }
+        public class AbsoluteCommandParameter : SimpleCommandParameter { }
+        public class InCommandParameter : SimpleCommandParameter { }
 
         public abstract class ValueCommandParameter<T> : SimpleCommandParameter {
             public T value;
@@ -246,7 +247,7 @@ namespace IngameScript {
             }
         }
 
-        public class AmbiguousSelectorCommandParameter : SelectorCommandParameter { 
+        public class AmbiguousSelectorCommandParameter : SelectorCommandParameter {
             public AmbiguousSelectorCommandParameter(BlockSelector value) : base(value) {
             }
         }


### PR DESCRIPTION
This PR introduces the following changes:
 *  Introduce new command parameters for `to` (`AbsoluteCommandParameter`) and `in` (`InCommandParameter`).
    All other tokens that are currently ignored can then be discarded before even invoking the actual parser.
    This allows removal of the rule that discards `IgnoreCommandParamter` and `IgnoreCommandParameter` itself.
 *  Modify the rule for `VariableIncrementParameter` to include a optional `RelativeCommmandParameter` (`by`).
    This allows removal of the rule that discards `RelativeCommandParameter`.
 *  Modify the rule for `IteratorComandParameter` to include a optional `InCommandParameter`.
     Modify the rules that produce `PropertySupplierCommandParameter`s to include a optional `InCommnadParameter` (`in`) to the left in case of the rule for `PropertyCommandParameter` and to the right in case of the rules for `ValuePropertyCommandParameter`.
    This handles all cases where `in` is used inside the test.
 *  ~~Add a rule to discard `AbsoluteCommandParameter` before the `BlockCommandParameter` rule.  This is a temporary measure to keep everything running for now . To resolve this the `BlockCommandParameter` rule most likley needs to be split into seperate cases for assignment and increment/increase.
    All the assignment rules either before or after the `BlockCommandParameter` need to be changed to consume a `AbsoluteCommandParameter`~~
    Add `AbsoluteCommnadParameter`s to various rules and do not discard it as a standalone CP.

Changes not yet included are:
* ~~Introduce a `IdentifierCommandParameter` to simplify/remove `CanConvert` with checks like `name.GetValue().value is AmbiguousStringVariable`.~~ _Added. see below_
* Replacement of `ParenethesisProcessor`, `ListProcessor` and `MultiListProcessor` with conventional rules. This might need some changes to the parser itself like a non consuming lookahead processor.
* Match processors for a rules in order of the defintion instead of unorderd. Currently any rule that matches more than one processor to the left or to the right can match these in any order and the preferred order of the left matches is also reversed. Atleast `BlockCommandProcessor` and the rules for item transfer (?) depend on this behaviour.
   As a first step add a paramter to `RuleProcessor` that allows to select the desired behaviour and determine how many rules depend on the old behaviour.


_As a side note :
I would propose to rename `*CommandParameter => *Token`, `*DataProcessor => *Match` and the current `Token => Lexeme`.
And maybe also renaming a few files to reflect what they contain `ParameterParser.cs => Lexer.cs`, `ProcessingEngine.cs => Parser.cs`_
     
_edit: 
07. April: updated some points above_

