### PR TITLE
Flexible property support

### DIFF
--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Commands/ComplexBlockCommandTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Commands/ComplexBlockCommandTests.cs
@@ -80,5 +80,51 @@ namespace EasyCommands.Tests.ScriptTests {
                 mockPiston2.Verify(b => b.Retract());
             }
         }
+
+        [TestMethod]
+        public void RearrangePropertyOfBlockConditionWithConditionalSelector() {
+            using (ScriptTest test = new ScriptTest(@"
+if the ratio of all batteries that are recharging < 0.5
+  Print ""Sound the alarm!""")) {
+                var mockBattery = new Mock<IMyBatteryBlock>();
+                var mockBattery2 = new Mock<IMyBatteryBlock>();
+                test.MockBlocksInGroup("My Batteries", mockBattery, mockBattery2);
+
+                mockBattery.Setup(b => b.ChargeMode).Returns(ChargeMode.Recharge);
+                mockBattery.Setup(b => b.CurrentStoredPower).Returns(10f);
+                mockBattery.Setup(b => b.MaxStoredPower).Returns(40f);
+
+                mockBattery2.Setup(b => b.ChargeMode).Returns(ChargeMode.Auto);
+                mockBattery2.Setup(b => b.CurrentStoredPower).Returns(30f);
+                mockBattery2.Setup(b => b.MaxStoredPower).Returns(40f);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Sound the alarm!", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void RearrangePropertyOfBlockConditionWithConditionalSelectorInParentheses() {
+            using (ScriptTest test = new ScriptTest(@"
+if the ratio of all (batteries that are recharging) < 0.5
+  Print ""Sound the alarm!""")) {
+                var mockBattery = new Mock<IMyBatteryBlock>();
+                var mockBattery2 = new Mock<IMyBatteryBlock>();
+                test.MockBlocksInGroup("My Batteries", mockBattery, mockBattery2);
+
+                mockBattery.Setup(b => b.ChargeMode).Returns(ChargeMode.Recharge);
+                mockBattery.Setup(b => b.CurrentStoredPower).Returns(10f);
+                mockBattery.Setup(b => b.MaxStoredPower).Returns(40f);
+
+                mockBattery2.Setup(b => b.ChargeMode).Returns(ChargeMode.Auto);
+                mockBattery2.Setup(b => b.CurrentStoredPower).Returns(30f);
+                mockBattery2.Setup(b => b.MaxStoredPower).Returns(40f);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Sound the alarm!", test.Logger[0]);
+            }
+        }
     }
 }

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Variables/MultiWordPropertyAggregationTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Variables/MultiWordPropertyAggregationTests.cs
@@ -104,9 +104,74 @@ if the ""test turret"" target velocity > 50
         }
 
         [TestMethod]
+        public void CheckPropertyWithPropertyWordsSplitAcrossSelectorAndComparison() {
+            using (ScriptTest test = new ScriptTest(@"
+if the steering of the ""test wheel"" is inverted
+  print ""Steering Is Inverted""
+")) {
+                var mockWheel = new Mock<IMyMotorSuspension>();
+                test.MockBlocksOfType("test wheel", mockWheel);
+
+                mockWheel.Setup(b => b.InvertSteer).Returns(true);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Steering Is Inverted", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
         public void CheckAnyMultiWordBlockProperty() {
             using (ScriptTest test = new ScriptTest(@"
 if any ""test turrets"" target velocity > 50
+  print ""Some are retreating!""
+            ")) {
+                var mockTurret = new Mock<IMyLargeTurretBase>();
+                var mockTurret2 = new Mock<IMyLargeTurretBase>();
+                test.MockBlocksInGroup("test turrets", mockTurret, mockTurret2);
+
+                mockTurret.Setup(b => b.CustomData).Returns("");
+                mockTurret.Setup(b => b.HasTarget).Returns(true);
+                mockTurret.Setup(b => b.GetTargetedEntity()).Returns(MockDetectedEntity(new Vector3D(1, 2, 3), new Vector3D(30, 30, 30)));
+
+                mockTurret2.Setup(b => b.CustomData).Returns("");
+                mockTurret2.Setup(b => b.HasTarget).Returns(true);
+                mockTurret2.Setup(b => b.GetTargetedEntity()).Returns(MockDetectedEntity(new Vector3D(1, 2, 3)));
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Some are retreating!", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void CheckAnyMultiWordBlockPropertyWithSplitPropertyWords() {
+            using (ScriptTest test = new ScriptTest(@"
+if the velocity of any ""test turrets"" target > 50
+  print ""Some are retreating!""
+            ")) {
+                var mockTurret = new Mock<IMyLargeTurretBase>();
+                var mockTurret2 = new Mock<IMyLargeTurretBase>();
+                test.MockBlocksInGroup("test turrets", mockTurret, mockTurret2);
+
+                mockTurret.Setup(b => b.CustomData).Returns("");
+                mockTurret.Setup(b => b.HasTarget).Returns(true);
+                mockTurret.Setup(b => b.GetTargetedEntity()).Returns(MockDetectedEntity(new Vector3D(1, 2, 3), new Vector3D(30, 30, 30)));
+
+                mockTurret2.Setup(b => b.CustomData).Returns("");
+                mockTurret2.Setup(b => b.HasTarget).Returns(true);
+                mockTurret2.Setup(b => b.GetTargetedEntity()).Returns(MockDetectedEntity(new Vector3D(1, 2, 3)));
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Some are retreating!", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void CheckAnyMultiWordBlockPropertyWithPropertyWordsInFront() {
+            using (ScriptTest test = new ScriptTest(@"
+if the target velocity of any ""test turrets"" > 50
   print ""Some are retreating!""
             ")) {
                 var mockTurret = new Mock<IMyLargeTurretBase>();

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Variables/SimpleAggregationTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Variables/SimpleAggregationTests.cs
@@ -357,6 +357,23 @@ if the ""test thruster"" output > 10000
         }
 
         [TestMethod]
+        public void CheckBlockPropertyWithPropertyInFront() {
+            using (ScriptTest test = new ScriptTest(@"
+if the range of the ""test beacon"" > 5000
+  print ""Long Range Beacon!""
+            ")) {
+                var mockBeacon = new Mock<IMyBeacon>();
+                test.MockBlocksOfType("test beacon", mockBeacon);
+
+                mockBeacon.Setup(b => b.Radius).Returns(10000);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Long Range Beacon!", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
         public void ImplicitBlockPropertyAggregation() {
             using (ScriptTest test = new ScriptTest(@"
 if any ""test thrusters"" output < 10000

--- a/EasyCommands/CommandParsers/CommandParameters.cs
+++ b/EasyCommands/CommandParsers/CommandParameters.cs
@@ -150,10 +150,6 @@ namespace IngameScript {
             }
         }
 
-        public class BooleanCommandParameter : ValueCommandParameter<bool> {
-            public BooleanCommandParameter(bool value) : base(value) {}
-        }
-
         public class DirectionCommandParameter : ValueCommandParameter<Direction> {
             public DirectionCommandParameter(Direction value) : base(value) {}
         }

--- a/EasyCommands/CommandParsers/CommandParameters.cs
+++ b/EasyCommands/CommandParsers/CommandParameters.cs
@@ -163,7 +163,10 @@ namespace IngameScript {
         }
 
         public class PropertyCommandParameter : ValueCommandParameter<Property> {
-            public PropertyCommandParameter(Property value) : base(value) { }
+            public bool inverse;
+            public PropertyCommandParameter(Property value, bool Inverse = false) : base(value) {
+                inverse = Inverse;
+            }
         }
 
         public class PropertyValueCommandParameter : ValueCommandParameter<PropertyValue> {

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -121,8 +121,8 @@ namespace IngameScript {
             AddWords(Words("by"), new RelativeCommandParameter());
 
             //Value Words
-            AddWords(Words("on", "begin", "true", "start", "started", "resume", "resumed"), new BooleanCommandParameter(true));
-            AddWords(Words("off", "terminate", "cancel", "end", "false", "stopped", "halt", "halted"), new BooleanCommandParameter(false));
+            AddWords(Words("on", "begin", "true", "start", "started", "resume", "resumed"), new VariableCommandParameter(GetStaticVariable(true)));
+            AddWords(Words("off", "terminate", "cancel", "end", "false", "stopped", "halt", "halted"), new VariableCommandParameter(GetStaticVariable(false)));
 
             //Property Words
             AddPropertyWords(AllWords(PluralWords("height", "length", "level", "size", "period", "scale")), Property.LEVEL);
@@ -399,10 +399,8 @@ namespace IngameScript {
             AddWords(words, new CommandReferenceParameter(new ControlCommand { controlFunction = function }));
         }
 
-        void AddPropertyWords(String[] words, Property property, bool nonNegative = true) {
-            if (!nonNegative) AddWords(words, new PropertyCommandParameter(property), new BooleanCommandParameter(false));
-            else AddWords(words, new PropertyCommandParameter(property));
-        }
+        void AddPropertyWords(String[] words, Property property, bool nonNegative = true) =>
+            AddWords(words, new PropertyCommandParameter(property, !nonNegative));
 
         void AddDirectionWords(String[] words, Direction direction) {
             AddWords(words, new DirectionCommandParameter(direction));

--- a/EasyCommands/CommandParsers/ProcessingEngine.cs
+++ b/EasyCommands/CommandParsers/ProcessingEngine.cs
@@ -119,7 +119,7 @@ namespace IngameScript {
                 (name, function) => new FunctionDefinitionCommandParameter(() => CastString(name.value.GetValue()), function.value)),
 
             //PropertyProcessor
-            NoValueRule(Type<PropertyCommandParameter>, p => new PropertyValueCommandParameter(new PropertyValue(p.value + "", p.Token))),
+            NoValueRule(Type<PropertyCommandParameter>, p => new PropertyValueCommandParameter(new PropertyValue(p.value + "", p.Token).Inverse(p.inverse))),
 
             //ValuePropertyProcessor
             //Needs to check left, then right, which is opposite the typical checks.
@@ -142,9 +142,6 @@ namespace IngameScript {
             OneValueRule(Type<IncrementCommandParameter>, requiredLeft<VariableCommandParameter>(),
                 (p, name) => name.Satisfied() && (name.GetValue().value is AmbiguousStringVariable),
                 (p, name) => new VariableIncrementCommandParameter(((AmbiguousStringVariable)name.value).value, p.value)),
-
-            //Primitive Processor
-            NoValueRule(Type<BooleanCommandParameter>, b => new VariableCommandParameter(GetStaticVariable(b.value))),
 
             //ListPropertyAggregationProcessor
             OneValueRule(Type<ListIndexCommandParameter>, requiredLeft<PropertyAggregationCommandParameter>(),

--- a/EasyCommands/CommandParsers/ProcessingEngine.cs
+++ b/EasyCommands/CommandParsers/ProcessingEngine.cs
@@ -241,6 +241,11 @@ namespace IngameScript {
             TwoValueRule(Type<ThatCommandParameter>, requiredLeft<SelectorCommandParameter>(), requiredRight<BlockConditionCommandParameter>(),
                 (p, selector, condition) => new SelectorCommandParameter(new ConditionalSelector(selector.value, condition.value))),
 
+            //Re-arrange PropertyValueCommandParameters
+            TwoValueRule(Type<PropertyValueCommandParameter>, optionalRight<AggregationModeCommandParameter>(), optionalRight<SelectorCommandParameter>(),
+                (p, a, s) => AnyNotNull(a.GetValue(), s.GetValue()),
+                (p, a, s) => NewList<ICommandParameter>(a, s, p).Where(c => c != null).ToList()),
+
             //PropertyAggregationProcessor
             ThreeValueRule(Type<PropertyAggregationCommandParameter>, requiredEither<SelectorCommandParameter>(), eitherList<PropertyValueCommandParameter>(false), optionalEither<DirectionCommandParameter>(),
                 (p, selector, prop, dir) => new VariableCommandParameter(new AggregatePropertyVariable(p.value, selector.value, new PropertySupplier(prop.Select(v => v.value).ToList()).WithDirection(dir?.value)))),

--- a/docs/EasyCommands/blockHandlers.md
+++ b/docs/EasyCommands/blockHandlers.md
@@ -12,24 +12,6 @@ Block Types define a mapping between specific keywords and a specific type of bl
 ### Block Properties
 Block Properties allow you to interact with properties of a given set of blocks, based on the [Selector's](https://spaceengineers.merlinofmines.com/EasyCommands/selectors "Selectors") block type.  Many blocks share the same properties, but the behavior is different for that block type.  For example, the "Range" property on a Gatling Turret will set the Gatling Turret's firing range, whereas "Range" on an antenna will set it's broadcasting distance.
 
-#### Multi-Word Block Properties
-Some Block Properties require multiple words to be specified, such as the "target velocity" property of a Sensor, Camera or Turret.  In the list of properties for each BlockHandler, these multi-word properties will be denoted by multiple words separated by a space.
-
-In general, I recommend specifying all words of a multi-word property consecutively, but you can technically get away with splitting them up in some cases.  For example, to invert the steering of a wheel, you can specify this multiple ways:
-
-```
-#These are equivalent
-set the "Test Wheel" invert steering to true
-invert the "Test Wheel" steering
-```
-
-Similarly, to get the target velocity of a turret, you can do the either of the following:
-```
-#These are equivalent
-Print "Target Velocity: " + "Test Turret" target velocity
-Print "Target Velocity: " + the velocity of the "Test Turret" target
-```
-
 ## Getting and Setting Block Properties
 
 Before I get into the supported Block Handlers, let's go over some basics of Block Properties.  These basics apply to all Block Handlers, so as you are reading through specific BlockHandlers, keep the behavior described below in mind.  The BlockHandler descriptions reference these concepts without explaining them in detail.
@@ -51,7 +33,32 @@ increase the "Base Antenna" range by 1000
 #Decrease a property value
 ```
 
-## Read-only Properties
+You can also specify the property words in front of the selector, such as:
+
+```
+print "Range: " + the range of my beacon
+print "Average: " + the average height of my pistons
+```
+
+### Multi-Word Block Properties
+Some Block Properties require multiple words to be specified, such as the "target velocity" property of a Sensor, Camera or Turret.  In the list of properties for each BlockHandler, these multi-word properties will be denoted by multiple words separated by a space.
+
+In general, I recommend specifying all words of a multi-word property consecutively, but you can technically get away with splitting them up in some cases.  For example, to invert the steering of a wheel, you can specify this multiple ways:
+
+```
+#These are equivalent
+set the "Test Wheel" invert steering to true
+invert the "Test Wheel" steering
+```
+
+Similarly, to get the target velocity of a turret, you can do the either of the following:
+```
+#These are equivalent
+Print "Target Velocity: " + "Test Turret" target velocity
+Print "Target Velocity: " + the velocity of the "Test Turret" target
+```
+
+### Read-only Properties
 Not all properties can be updated.  These properties will be labeled "Read-only" and can only be retrieved.  Examples include be "Position", "Direction", "Properties", etc.
 
 ## Moving Properties


### PR DESCRIPTION
This PR adds a useful feature for specifying block properties by enabling the user to specify the property word(s) in front of the selector, such as:

```print "Range: " + the range of my turrets```

It also removes the unnecessary "BooleanCommandParameter" type, which was only used to indicate inversion of properties.  This has been moved directly onto the property parameter.