### PR TITLE
Added Able (ready) Property

### DIFF
--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/ConnectorBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/ConnectorBlockTests.cs
@@ -151,5 +151,58 @@ namespace EasyCommands.Tests.ScriptTests {
                 mockConnector.Verify(b => b.Disconnect());
             }
         }
+
+        [TestMethod]
+        public void IsTheConnectorReady() {
+            using (ScriptTest test = new ScriptTest(@"Print ""Ready: "" + ""test connector"" is ready")) {
+                Mock<IMyShipConnector> mockConnector = new Mock<IMyShipConnector>();
+                test.MockBlocksOfType("test connector", mockConnector);
+                mockConnector.Setup(b => b.Status).Returns(MyShipConnectorStatus.Connectable);
+
+                test.RunUntilDone();
+
+                Assert.IsTrue(test.Logger.Contains("Ready: True"));
+            }
+        }
+
+        [TestMethod]
+        public void IsTheConnectorReadyWhenNotReady() {
+            using (ScriptTest test = new ScriptTest(@"Print ""Ready: "" + ""test connector"" is ready")) {
+                Mock<IMyShipConnector> mockConnector = new Mock<IMyShipConnector>();
+                test.MockBlocksOfType("test connector", mockConnector);
+                mockConnector.Setup(b => b.Status).Returns(MyShipConnectorStatus.Connected);
+
+                test.RunUntilDone();
+
+                Assert.IsTrue(test.Logger.Contains("Ready: False"));
+            }
+        }
+
+        [TestMethod]
+        public void IsTheConnectorReadyToConnect() {
+            using (ScriptTest test = new ScriptTest(@"Print ""Ready: "" + ""test connector"" is able to be connected")) {
+                Mock<IMyShipConnector> mockConnector = new Mock<IMyShipConnector>();
+                test.MockBlocksOfType("test connector", mockConnector);
+                mockConnector.Setup(b => b.Status).Returns(MyShipConnectorStatus.Connectable);
+
+                test.RunUntilDone();
+
+                Assert.IsTrue(test.Logger.Contains("Ready: True"));
+            }
+        }
+
+        [TestMethod]
+        public void TheConnectorCanBeLocked() {
+            using (ScriptTest test = new ScriptTest(@"Print ""Ready: "" + ""test connector"" can be locked")) {
+                Mock<IMyShipConnector> mockConnector = new Mock<IMyShipConnector>();
+                test.MockBlocksOfType("test connector", mockConnector);
+                mockConnector.Setup(b => b.Status).Returns(MyShipConnectorStatus.Connectable);
+
+                test.RunUntilDone();
+
+                Assert.IsTrue(test.Logger.Contains("Ready: True"));
+            }
+        }
+
     }
 }

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/JumpDriveBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/JumpDriveBlockTests.cs
@@ -91,6 +91,19 @@ namespace EasyCommands.Tests.ScriptTests {
         }
 
         [TestMethod]
+        public void IsJumpDriveComplete() {
+            using (ScriptTest test = new ScriptTest(@"Print ""Jump Drive Ready: "" + ""test jumpdrive"" is complete")) {
+                Mock<IMyJumpDrive> mockJumpDrive = new Mock<IMyJumpDrive>();
+                test.MockBlocksOfType("test jumpdrive", mockJumpDrive);
+                mockJumpDrive.Setup(b => b.Status).Returns(MyJumpDriveStatus.Ready);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Jump Drive Ready: True", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
         public void IsJumpDriveReady() {
             using (ScriptTest test = new ScriptTest(@"Print ""Jump Drive Ready: "" + ""test jumpdrive"" is ready")) {
                 Mock<IMyJumpDrive> mockJumpDrive = new Mock<IMyJumpDrive>();

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/LandingGearBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/LandingGearBlockTests.cs
@@ -129,5 +129,57 @@ namespace EasyCommands.Tests.ScriptTests {
                 mockLandingGear.VerifySet(b => b.AutoLock = true);
             }
         }
+
+        [TestMethod]
+        public void IsLandingGearReady() {
+            using (ScriptTest test = new ScriptTest(@"Print ""Ready To Lock: "" + the ""test landing gear"" is ready")) {
+                Mock<IMyLandingGear> mockLandingGear = new Mock<IMyLandingGear>();
+                test.MockBlocksOfType("test landing gear", mockLandingGear);
+                mockLandingGear.Setup(b => b.LockMode).Returns(LandingGearMode.ReadyToLock);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Ready To Lock: True", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void IsLandingGearReadyWhenConnectedReturnFalse() {
+            using (ScriptTest test = new ScriptTest(@"Print ""Ready To Lock: "" + the ""test landing gear"" is ready")) {
+                Mock<IMyLandingGear> mockLandingGear = new Mock<IMyLandingGear>();
+                test.MockBlocksOfType("test landing gear", mockLandingGear);
+                mockLandingGear.Setup(b => b.LockMode).Returns(LandingGearMode.Locked);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Ready To Lock: False", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void IsLandingGearReadyToLock() {
+            using (ScriptTest test = new ScriptTest(@"Print ""Ready To Lock: "" + the ""test landing gear"" is ready to lock")) {
+                Mock<IMyLandingGear> mockLandingGear = new Mock<IMyLandingGear>();
+                test.MockBlocksOfType("test landing gear", mockLandingGear);
+                mockLandingGear.Setup(b => b.LockMode).Returns(LandingGearMode.ReadyToLock);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Ready To Lock: True", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void IsLandingGearReadyToConnect() {
+            using (ScriptTest test = new ScriptTest(@"Print ""Ready to Connect: "" + the ""test landing gear"" is ready to connect")) {
+                Mock<IMyLandingGear> mockLandingGear = new Mock<IMyLandingGear>();
+                test.MockBlocksOfType("test landing gear", mockLandingGear);
+                mockLandingGear.Setup(b => b.LockMode).Returns(LandingGearMode.ReadyToLock);
+
+                test.RunUntilDone();
+
+                Assert.AreEqual("Ready to Connect: True", test.Logger[0]);
+            }
+        }
     }
 }

--- a/EasyCommands/BlockHandlers/ConnectorBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/ConnectorBlockHandlers.cs
@@ -21,16 +21,18 @@ namespace IngameScript {
     partial class Program {
         public class ConnectorBlockHandler : EjectorBlockHandler {
             public ConnectorBlockHandler() {
-                AddBooleanHandler(Property.LOCKED, Connected, Connect);
-                AddBooleanHandler(Property.CONNECTED, Connected, Connect);
+                var connectedHandler = BooleanHandler(b => b.Status == MyShipConnectorStatus.Connected, (b, v) => { if (v) b.Connect(); else b.Disconnect(); });
+
+                AddPropertyHandler(Property.LOCKED, connectedHandler);
+                AddPropertyHandler(Property.CONNECTED, connectedHandler);
                 AddNumericHandler(Property.STRENGTH, b => b.PullStrength, (b, v) => b.PullStrength = v, 0.01f);
+
+                var readyHandler = BooleanHandler(b => b.Status == MyShipConnectorStatus.Connectable);
+                AddPropertyHandler(Property.ABLE, readyHandler);
+                AddPropertyHandler(NewList(Property.ABLE, Property.LOCKED), readyHandler);
+                AddPropertyHandler(NewList(Property.ABLE, Property.CONNECTED), readyHandler);
+
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.STRENGTH;
-            }
-
-            static bool Connected(IMyShipConnector connector) => connector.Status == MyShipConnectorStatus.Connected;
-
-            static void Connect(IMyShipConnector connector, bool value) {
-                if (value) { connector.Connect(); } else { connector.Disconnect(); }
             }
         }
 

--- a/EasyCommands/BlockHandlers/JumpDriveBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/JumpDriveBlockHandlers.cs
@@ -23,7 +23,9 @@ namespace IngameScript {
             public JumpDriveBlockHandler() {
                 AddNumericHandler(Property.POWER, b => b.CurrentStoredPower);
                 AddNumericHandler(Property.RATIO, b => b.CurrentStoredPower / b.MaxStoredPower);
-                AddBooleanHandler(Property.COMPLETE, b => b.Status == MyJumpDriveStatus.Ready);
+                var readyHandler = BooleanHandler(b => b.Status == MyJumpDriveStatus.Ready);
+                AddPropertyHandler(Property.COMPLETE, readyHandler);
+                AddPropertyHandler(Property.ABLE, readyHandler);
                 AddBooleanHandler(Property.SUPPLY, b => !b.Recharge, (b, v) => b.Recharge = !v);
 
                 var jumpDistanceHandler = DirectionalTypedHandler(Direction.NONE,

--- a/EasyCommands/BlockHandlers/LandingGearHandlers.cs
+++ b/EasyCommands/BlockHandlers/LandingGearHandlers.cs
@@ -25,6 +25,11 @@ namespace IngameScript {
                 var lockHandler = BooleanHandler(b => b.IsLocked, (b, v) => { if (v) b.Lock(); else b.Unlock(); });
                 AddPropertyHandler(Property.LOCKED, lockHandler);
                 AddPropertyHandler(Property.CONNECTED, lockHandler);
+
+                var readyHandler = BooleanHandler(b => b.LockMode == LandingGearMode.ReadyToLock);
+                AddPropertyHandler(Property.ABLE, readyHandler);
+                AddPropertyHandler(NewList(Property.ABLE, Property.LOCKED), readyHandler);
+                AddPropertyHandler(NewList(Property.ABLE, Property.CONNECTED), readyHandler);
             }
         }
     }

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -135,7 +135,7 @@ namespace IngameScript {
             AddPropertyWords(Words("run", "running", "execute", "executing", "script"), Property.RUN);
             AddPropertyWords(Words("use", "used", "occupy", "occupied", "control", "controlled"), Property.USE);
             AddPropertyWords(Words("unused", "unoccupied", "vacant", "available"), Property.USE, false);
-            AddPropertyWords(Words("done", "ready", "complete", "finished", "built", "finish", "pressurized", "depressurized"), Property.COMPLETE);
+            AddPropertyWords(Words("done", "complete", "finished", "built", "finish", "pressurized", "depressurized"), Property.COMPLETE);
             AddPropertyWords(Words("clear", "wipe", "erase"), Property.COMPLETE, false);
             AddPropertyWords(Words("open", "opened"), Property.OPEN);
             AddPropertyWords(Words("close", "closed", "shut"), Property.OPEN, false);
@@ -185,6 +185,8 @@ namespace IngameScript {
             AddPropertyWords(Words("info", "details", "detailedinfo"), Property.INFO);
             AddPropertyWords(Words("invert", "inverted", "inverting"), Property.INVERT);
             AddPropertyWords(Words("steer", "steering"), Property.STEER);
+            AddPropertyWords(Words("able", "ready"), Property.ABLE);
+            AddPropertyWords(Words("unable"), Property.ABLE, false);
 
             //ValueProperty Words
             AddWords(PluralWords("amount"), new ValuePropertyCommandParameter(Property.AMOUNT));
@@ -387,6 +389,9 @@ namespace IngameScript {
             AddBlockWords(Words("searchlight"), Block.SEARCHLIGHT);
             AddBlockWords(Words("turretcontroller"), Block.TURRET_CONTROLLER);
             AddBlockWords(PluralWords("grid"), Words(), Block.GRID);
+
+            AddAliasWords(Words("can"), "is able");
+            AddAliasWords(Words("cannot"), "is not able");
         }
 
         String[] Words(params String[] words) => words;
@@ -436,6 +441,10 @@ namespace IngameScript {
 
         void AddWords(String[] words, params ICommandParameter[] commandParameters) {
             foreach (String word in words) propertyWords.Add(word, commandParameters.ToList());
+        }
+
+        void AddAliasWords(String[] words, string aliasWords) {
+            AddWords(words, PROGRAM.ParseCommandParameters(PROGRAM.Tokenize(aliasWords)).ToArray());
         }
 
         public List<Token> Tokenize(String commandString) => tokenize(commandString).ToList();

--- a/EasyCommands/CommandParsers/ProcessingEngine.cs
+++ b/EasyCommands/CommandParsers/ProcessingEngine.cs
@@ -118,7 +118,10 @@ namespace IngameScript {
             OneValueRule(Type<VariableCommandParameter>, requiredLeft<FunctionCommandParameter>(),
                 (name, function) => new FunctionDefinitionCommandParameter(() => CastString(name.value.GetValue()), function.value)),
 
-            //PropertyProcessor
+            //PropertyProcessors
+            TwoValueRule(Type<PropertyCommandParameter>, requiredRight<CommandSeparatorCommandParameter>(), requiredRight<PropertyCommandParameter>(),
+                (ready, to, p) => AllSatisfied(to, p) && ready.value == Property.ABLE,
+                (ready, to, p) => NewList<ICommandParameter>(ready, p)),
             NoValueRule(Type<PropertyCommandParameter>, p => new PropertyValueCommandParameter(new PropertyValue(p.value + "", p.Token).Inverse(p.inverse))),
 
             //ValuePropertyProcessor

--- a/EasyCommands/Common/Types.cs
+++ b/EasyCommands/Common/Types.cs
@@ -83,6 +83,7 @@ namespace IngameScript {
 
         public enum Property {
             //Simple Properties
+            ABLE,
             ACTIONS,
             ALTITUDE,
             ANGLE,

--- a/docs/EasyCommands/blockHandlers/connector.md
+++ b/docs/EasyCommands/blockHandlers/connector.md
@@ -72,6 +72,45 @@ disconnect "My Connector"
 
 Identical to the Connect Property
 
+## "Ready" Property
+* Primitive Type: Bool
+* Read-only
+* Keywords: ```ready, able```
+* Inverse Keywords: ```unable```
+
+Returns true if the connector is ready to connect, false if already connected or not ready to connect.
+
+```
+if "My Connector" is ready
+  Print "Ready to Connect!"
+```
+
+## "Ready Connect" Property
+* Primitive Type: Bool
+* Read-only
+* Keywords: ```ready to connect, able to connect, can connect```
+* Inverse Keywords: ```unable to connect, cannot connect```
+
+Same as Ready. Returns true if the connector is ready to connect, false if already connected or not ready to connect.
+
+```
+if "My Connector" is ready to connect
+  Print "Ready to Connect!"
+```
+
+## "Ready Lock" Property
+* Primitive Type: Bool
+* Read-only
+* Keywords: ```ready to lock, able to lock, can lock```
+* Inverse Keywords: ```unable to lock, cannot lock```
+
+Same as Ready. Returns true if the connector is ready to connect, false if already connected or not ready to connect.
+
+```
+if "My Connector" is ready to lock
+  Print "Ready to Connect!"
+```
+
 ## "Strength" Property
 * Primitive Type: Numeric
 * Keywords: ```strength, strengths, force, forces```

--- a/docs/EasyCommands/blockHandlers/jumpDrive.md
+++ b/docs/EasyCommands/blockHandlers/jumpDrive.md
@@ -91,11 +91,23 @@ set "My Jump Drive" length to 10000
 ```
 
 ## "Complete" Property
-* Read-only
 * Primitive Type: Bool
-* Keywords: ```complete, ready, done, finished```
+* Read-only
+* Keywords: ```complete, done, finished```
 
 Returns whether the Jump Drive is ready to jump.  Specifically, whether the Jump Drive's status is READY.
+
+```
+if "My Jump Drive" is finished
+  Print "Ready to Jump!"
+```
+
+## "Ready" Property
+* Primitive Type: Bool
+* Read-only
+* Keywords: ```ready, able```
+* Inverse Keywords: ```unable```
+Same as Complete. Returns whether the Jump Drive is ready to jump.  Specifically, whether the Jump Drive's status is READY.
 
 ```
 if "My Jump Drive" is ready

--- a/docs/EasyCommands/blockHandlers/landingGear.md
+++ b/docs/EasyCommands/blockHandlers/landingGear.md
@@ -74,6 +74,45 @@ until "My Landing Gear" is connected
 disconnect "My Landing Gear"
 ```
 
+## "Ready" Property
+* Primitive Type: Bool
+* Read-only
+* Keywords: ```ready, able```
+* Inverse Keywords: ```unable```
+
+Returns true if the landing gear is ready to connect, false if already connected or not ready to connect.
+
+```
+if "My Landing Gear" is ready
+  Print "Ready to Connect!"
+```
+
+## "Ready Connect" Property
+* Primitive Type: Bool
+* Read-only
+* Keywords: ```ready to connect, able to connect, can connect```
+* Inverse Keywords: ```unable to connect, cannot connect```
+
+Same as Ready. Returns true if the landing gear is ready to connect, false if already connected or not ready to connect.
+
+```
+if "My Landing Gear" is ready to connect
+  Print "Ready to Connect!"
+```
+
+## "Ready Lock" Property
+* Primitive Type: Bool
+* Read-only
+* Keywords: ```ready to lock, able to lock, can lock```
+* Inverse Keywords: ```unable to lock, cannot lock```
+
+Same as Ready. Returns true if the landing gear is ready to connect, false if already connected or not ready to connect.
+
+```
+if "My Landing Gear" is ready to lock
+  Print "Ready to Connect!"
+```
+
 ## "Auto" Property
 * Primitive Type: Bool
 * Keywords: ```auto```

--- a/docs/EasyCommands/cheatsheet.md
+++ b/docs/EasyCommands/cheatsheet.md
@@ -19,7 +19,7 @@ These words are (mostly) ignored when parsing your script, but feel free to use 
 * Self Selector - ```my, self, this``` 
 * Variable Selector - ```$```
 
-### Block Types (Single, Group)
+### Block Types (Single, Group) 
 * Air Vent - ```airvent, vent```, ```airvents, vents```
 * Antenna - ```antenna```, ```antennas```
 * Assembler - ```assembler```, ```assemblers```
@@ -77,6 +77,7 @@ These words are (mostly) ignored when parsing your script, but feel free to use 
 * Wind Turbine - ```turbine```, ```turbines```
 
 ## Properties (Inverse in Parentheses, if present)
+* Able - ```able, can, ready```, (```unable, cannot```)
 * Actions - ```actions```
 * Altitude - ```altitude, altitudes, elevation, elevations```
 * Angle - ```angle, angles, azimuth, azimuths```
@@ -85,7 +86,7 @@ These words are (mostly) ignored when parsing your script, but feel free to use 
 * Background - ```background```
 * Color - ```color, foreground```
 * Complete - 
-  * ```done, ready, complete, finished, built, finish, pressurized, depressurized```
+  * ```done, complete, finished, built, finish, pressurized, depressurized```
   * (```clear, wipe, erase```)
 * Connected -
   * ```connect, connected, attach, attached, dock, docked, docking```


### PR DESCRIPTION
This commit adds a new property for "Able", as well as a small processing rule to handle "ready to connect" and similar phrases.

It also adds new "ready to connect/lock" support to landing gear and connectors.