### PR TITLE
Fixed Implicit Aggregation Support

### DIFF
--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Variables/SimpleAggregationTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Variables/SimpleAggregationTests.cs
@@ -11,12 +11,12 @@ namespace EasyCommands.Tests.ScriptTests {
     public class SimpleAggregationTests {
 
         [TestMethod]
-        public void ValueOfEmptyListReturnsZero() {
+        public void ValueOfEmptyListReturnsEmptyList() {
             using (var test = new ScriptTest(@"Print ""My Value: "" + ""test piston"" height")) {
 
                 test.RunOnce();
 
-                Assert.AreEqual("My Value: 0", test.Logger[0]);
+                Assert.AreEqual("My Value: []", test.Logger[0]);
             }
         }
 
@@ -73,7 +73,7 @@ namespace EasyCommands.Tests.ScriptTests {
         }
 
         [TestMethod]
-        public void ValueOfMultipleItemsReturnsSum() {
+        public void ValueOfMultipleNumericItemsReturnsSum() {
             using (var test = new ScriptTest(@"Print ""My Value: "" + ""test piston"" height")) {
                 var mockPiston = new Mock<IMyPistonBase>();
                 var mockPiston2 = new Mock<IMyPistonBase>();
@@ -84,6 +84,21 @@ namespace EasyCommands.Tests.ScriptTests {
                 test.RunOnce();
 
                 Assert.AreEqual("My Value: 8", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void ValueOfMultipleNonNumericItemsReturnsSum() {
+            using (var test = new ScriptTest(@"Print ""My Value: "" + piston names")) {
+                var mockPiston = new Mock<IMyPistonBase>();
+                var mockPiston2 = new Mock<IMyPistonBase>();
+                test.MockBlocksInGroup("test pistons", mockPiston, mockPiston2);
+                mockPiston.Setup(b => b.CustomName).Returns("piston 1");
+                mockPiston2.Setup(b => b.CustomName).Returns("piston 2");
+
+                test.RunOnce();
+
+                Assert.AreEqual("My Value: [\"piston 1\",\"piston 2\"]", test.Logger[0]);
             }
         }
 

--- a/EasyCommands/BlockHandlers/BlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/BlockHandlers.cs
@@ -103,8 +103,8 @@ namespace IngameScript {
             public Direction defaultDirection = Direction.UP;
 
             public BlockHandler() {
-                AddListHandler(Property.NAMES, b => CastList(ResolvePrimitive(Name(b))));
-                defaultPropertiesByPrimitive[Return.STRING] = Property.NAMES;
+                AddStringHandler(Property.NAME, b => Name(b));
+                defaultPropertiesByPrimitive[Return.STRING] = Property.NAME;
             }
 
             public string GetName(object block) => Name((T)block);

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -172,8 +172,7 @@ namespace IngameScript {
             AddPropertyWords(Words("natural", "planet"), Property.NATURAL);
             AddPropertyWords(Words("artificial", "fake"), Property.ARTIFICIAL);
             AddPropertyWords(PluralWords("countdown"), Property.COUNTDOWN);
-            AddPropertyWords(Words("name", "label"), Property.NAME);
-            AddPropertyWords(Words("names", "labels"), Property.NAMES);
+            AddPropertyWords(PluralWords("name", "label"), Property.NAME);
             AddPropertyWords(Words("show", "showing"), Property.SHOW);
             AddPropertyWords(Words("hide", "hiding"), Property.SHOW, false);
             AddPropertyWords(Words("properties", "attributes"), Property.PROPERTIES);

--- a/EasyCommands/CommandParsers/ProcessingEngine.cs
+++ b/EasyCommands/CommandParsers/ProcessingEngine.cs
@@ -321,7 +321,7 @@ namespace IngameScript {
             new BranchingProcessor<SelectorPropertyCommandParameter>(
                 BlockCommandProcessor(),
                 NoValueRule(Type<SelectorPropertyCommandParameter>,
-                    s => new VariableCommandParameter(new AggregatePropertyVariable(PROGRAM.SumAggregator, s.selector, s.propertySupplier))),
+                    s => new VariableCommandParameter(new AggregatePropertyVariable(PROGRAM.DefaultAggregator, s.selector, s.propertySupplier))),
                 NoValueRule(Type<SelectorPropertyCommandParameter>,
                     s => {
                         var property = s.propertySupplier;

--- a/EasyCommands/Common/Aggregators.cs
+++ b/EasyCommands/Common/Aggregators.cs
@@ -21,5 +21,14 @@ namespace IngameScript {
     partial class Program {
         public delegate Primitive Aggregator(IEnumerable<object> blocks, Func<object,Primitive> primitiveSupplier);
         public Aggregator SumAggregator = (blocks, primitiveSupplier) => blocks.Select(primitiveSupplier).Aggregate((Primitive)null, (a, b) => a?.Plus(b) ?? b) ?? ResolvePrimitive(0);
+        public Aggregator DefaultAggregator = (blocks, primitiveSupplier) => {
+            var blockValues = blocks
+                .Select(primitiveSupplier)
+                .DefaultIfEmpty(ResolvePrimitive(NewKeyedList()));
+
+            return (blockValues.Count() == 1) ? blockValues.First() :
+                blockValues.All(v => v.returnType == Return.NUMERIC) ? blockValues.Aggregate((a, b) => a.Plus(b)) :
+                ResolvePrimitive(NewKeyedList(blockValues.Select(v => new StaticVariable(v))));
+        };
     }
 }

--- a/EasyCommands/Common/Types.cs
+++ b/EasyCommands/Common/Types.cs
@@ -108,7 +108,6 @@ namespace IngameScript {
             MEDIA_LIST,
             MEDIA,
             NAME,
-            NAMES,
             NATURAL,
             OFFSET,
             OPEN,

--- a/docs/EasyCommands/blockHandlers/display.md
+++ b/docs/EasyCommands/blockHandlers/display.md
@@ -15,26 +15,19 @@ Default Directional Properties
 * Up - Text
 
 Note that there are no Display Block Group keywords.  This is because individual blocks often have more than 1 display (Cockpits, Programmable Blocks).  If you want to get all displays from a group of blocks, use ```"My Displays" group displays```
- 
-## "Names" Property
-* Primitive Type: Bool
-* Keywords: ```enable, enabled```
-
-* Primitive Type: Bool
-* Keywords: ```names, labels```
-
-Prints the Display Name for the given display, as a list.  This enables you to get back all Display Names for a given block by doing:
-
-```
-Print "Display names: " + "My Programmabl Block" display names
-```
 
 ## "Name" Property
 * Read-only
 * Primitive Type: Bool
-* Keywords: ```name, label```
+* Keywords: ```name, names, label, labels```
 
-Prints the Display Name for the given display.  
+Prints the Display Name for the given display.
+
+This property also enables you to get back all Display Names for a given block by doing:
+
+```
+Print "Display names: " + "My Programmable Block" display names
+```
 
 You can update a given block's displays by named index using the display name, as follows:
 
@@ -42,7 +35,7 @@ You can update a given block's displays by named index using the display name, a
 #Keyboard
 Print "My Program" display [1] name
 
-set "My Program" display ["Keyboard"] to "My Keyboard Text"
+set "My Program" display ["Keyboard"] text to "My Keyboard Text"
 ```
 
 ## "Enabled" Property

--- a/docs/EasyCommands/blockHandlers/inventory.md
+++ b/docs/EasyCommands/blockHandlers/inventory.md
@@ -18,7 +18,7 @@ Default Primitive Properties:
 
 ## "Name" Property
 * Primitive Type: String
-* Keywords: ```name```
+* Keywords: ```name, names, label, labels```
 
 Gets/Sets the name of the block for which this container belongs.  Most useful for re-naming Cargo Container objects.
 

--- a/docs/EasyCommands/blockHandlers/terminal.md
+++ b/docs/EasyCommands/blockHandlers/terminal.md
@@ -9,12 +9,20 @@ Default Primitive Properties:
 * Bool - enabled
 * Vector - position
 
-### "Names" property
-* Read-only
+### "Name" property
 * Primitive Type: String
-* Keywords: ```names```
+* Keywords: ```name, names, label, labels```
 
-Returns a list of names for all of the blocks in the given selector.  Useful for getting a list of all block's names in a given group so that you can print out or iterate through each one to do something.  Good use cases for this might be for re-naming a group of blocks according to some pattern.  A cool script might prefix all of the blocks on your grid with some value so that later you know that those blocks belong to that ship. Example for doing this:
+Gets or sets the CustomName of the given Terminal Block (the name you see in the Terminal menu).
+
+This property can also be useful for getting a list of names for all blocks in a given selector:
+
+```
+set nameList to "My Turret" names
+print "My Turret Names: " + nameList
+```
+
+You can also use this to rename all blocks in your grid with a unique prefix, like so:
 
 ```
 set prefix to "[Base] "
@@ -27,12 +35,6 @@ for each turretName in the turret names
 ```
 
 Careful using this, as if you have too many blocks you can easily get the Script Too Complex issue.  If this happens, try getting block names for individual block types instead.
-
-### "Name" property
-* Primitive Type: String
-* Keywords: ```name```
-
-Gets or sets the CustomName of the given Terminal Block (the name you see in the Terminal menu).  
 
 ### "Show" property
 * Primitive Type: Bool

--- a/docs/EasyCommands/cheatsheet.md
+++ b/docs/EasyCommands/cheatsheet.md
@@ -105,8 +105,7 @@ These words are (mostly) ignored when parsing your script, but feel free to use 
   * (```unlock, unlocked, unfreeze```)
 * Media - ```sound, music, song, track, image, play, playing, unsilence``` (```silent, silence, quiet```)
 * Media List - ```sounds, songs, images, tracks```
-* Name - ```name, label```
-* Names - ```names, labels```
+* Name - ```name, names, label, labels```
 * Natural - ```natural, planet```
 * Offset (also Padding)- ```offset, padding```
 * Open - ```open, opened``` ```(close, closed, shut)```

--- a/docs/EasyCommands/variables.md
+++ b/docs/EasyCommands/variables.md
@@ -236,15 +236,26 @@ Aggregate Variables typically take the form of ```<Aggregator> <Selector> <Prope
 If a property is not explicitly provided, the aggregation will attempt to use the default numeric property for the selector's [Block Type](https://spaceengineers.merlinofmines.com/EasyCommands/blockHandlers "Block Handlers").
 
 ### Implicit Aggregation
+Whenever you request a selector's property, you are implicitly asking for an Aggregation.  When an explicit aggregation is not specified, a special default aggregator is used, with the returned value as follows:
+* If there are no blocks in the given selector, returns an empty list (```[]```).
+* If there is only 1 block in the given selector, returns the selector's property directly.
+* If there are more than 1 blocks in the given selector and all property values are numeric, returns the total sum of all block property values.
+* If there are more than 1 blocks in the given selector and not all property values are numeric, returns a list containing the property values of all the given blocks.
 
-Whenever you request a selector's property, you are implicitly asking for an Aggregation.  When an explicit aggregation is not specified, SUM is used.  As such, requesting a selector for a single block property has the effect of getting the block's property since it's a sum of 1 block.
+Therefore, if you only have 1 block in your selector and ask for a property value, that value will be returned directly.  If your selector has no blocks you will get back an empty list.  Otherwise, you will get either a sum of the selector block's property values (if numeric) or a list of the selector block's property values otherwise.
 
 ```
 #Implicit Aggregation since "my" will be a selector for the current Programmable Block
 set myName to my name
 Print "My name is: " + myName
 
-#Implicit Aggregation assuming there is only 1 block named "My Piston".  Will return a SUM of both if there are more than 1 blocks named "My Piston"
+#Implicit Aggregation for a selector with no blocks in it.  Will return an empty list.
+set myValue to "Invalid BlockName" terminal names
+
+#Implicit Aggregation for a list of blocks (assuming you have multiple turrets).  Since names is a string property, will return a list of names for your turruts.
+set myNames to the turret names
+
+#Implicit Aggregation assuming there is only 1 block named "My Piston".  Since height is a numeric property, will return a SUM of both if there are more than 1 blocks named "My Piston"
 set pistonHeight to "My Piston" height
 ```
 


### PR DESCRIPTION
This commit changes the default aggregation mode to use a new special default aggregation instead of a sum.  This aggregation will return an empty list for an empty
selector, or the selector property directly for a selector of 1 block.  If the selector has multiple blocks, the aggregator will return the sum of the values if all
are numeric; otherwise will return a list containing the property values for each selector block.

This commit also consolidates the "name" and "names" properties, as this commit removes the unnecessary (and confusing) distinction between the two properties.