### PR TITLE
Fixed issue with removing broadcast listeners causing a script haltin…

### DIFF
--- a/EasyCommands/Program.cs
+++ b/EasyCommands/Program.cs
@@ -80,11 +80,11 @@ namespace IngameScript {
             );
         }
 
-        public void BroadCastListenerAction(Func<IMyBroadcastListener, bool> filter, Action<IMyBroadcastListener> action) =>
-            IGC.GetBroadcastListeners(null, listener => {
-                if (filter(listener)) action(listener);
-                return false;
-            });
+        public void BroadCastListenerAction(Func<IMyBroadcastListener, bool> filter, Action<IMyBroadcastListener> action) {
+            var listeners = NewList<IMyBroadcastListener>();
+            IGC.GetBroadcastListeners(listeners, filter);
+            listeners.ForEach(action);
+        }
 
         public Thread GetCurrentThread() => currentThread;
 


### PR DESCRIPTION
…g exception

This commit fixes a bug whereby removing broadcast listeners would cause an enumeration exception as we were modifying a list while iterating over it.

This PR resolves #249 