### PR TITLE
Added support for custom number formatting

### DIFF
--- a/EasyCommands.Tests/ParameterParsingTests/ParsingTestUtility.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/ParsingTestUtility.cs
@@ -16,6 +16,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
         public static Program CreateProgram() {
             Program program = MDKFactory.CreateProgram<Program>();
             Program.PROGRAM = program;
+            program.SetGlobalVariable(Program.NUMBER_FORMAT, Program.GetStaticVariable("#0.########"));
             return program;
         }
     }

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/SimpleCastTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Operations/SimpleCastTests.cs
@@ -475,6 +475,7 @@ Print false as number
             var script = @"
 Print 1 as number
 Print 0.0 as number
+Print 1000000000000000 as number
 ";
 
             using (var test = new ScriptTest(script)) {
@@ -482,6 +483,39 @@ Print 0.0 as number
 
                 Assert.AreEqual("1", test.Logger[0]);
                 Assert.AreEqual("0", test.Logger[1]);
+                Assert.AreEqual("1000000000000000", test.Logger[2]);
+            }
+        }
+
+        [TestMethod]
+        public void CastNumberWithRoundedFormatting() {
+            var script = @"
+set global NUMBER_FORMAT to ""#0.##""
+Print 1 as number
+Print 0.006 as number
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.AreEqual("1", test.Logger[0]);
+                Assert.AreEqual("0.01", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void CastNumberWithSpecialFormatting() {
+            var script = @"
+set global NUMBER_FORMAT to ""$#0.00""
+Print 1 as number
+Print 0.0 as number
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.RunOnce();
+
+                Assert.AreEqual("$1.00", test.Logger[0]);
+                Assert.AreEqual("$0.00", test.Logger[1]);
             }
         }
 

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Variables/SimpleVariableTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Variables/SimpleVariableTests.cs
@@ -101,6 +101,21 @@ Print ""e is: "" + e
         }
 
         [TestMethod]
+        public void NumberFormatIsAvailable() {
+            var script = @"
+Print ""NUMBER_FORMAT is: "" + NUMBER_FORMAT
+";
+
+            using (var test = new ScriptTest(script)) {
+                test.program.logLevel = Program.LogLevel.INFO;
+
+                test.RunOnce();
+
+                Assert.IsTrue(test.Logger.Contains("NUMBER_FORMAT is: #0.########"));
+            }
+        }
+
+        [TestMethod]
         public void ReverseBoolean() {
             var script = @"
 set a to true

--- a/EasyCommands/Common/Primitives.cs
+++ b/EasyCommands/Common/Primitives.cs
@@ -60,6 +60,7 @@ namespace IngameScript {
                 CastFunction(Return.DEFAULT, Failure(Return.NUMERIC))
             )),
             KeyValuePair(typeof(string), NewDictionary(
+                CastFunction(Return.NUMERIC, p => CastNumber(p).ToString(PROGRAM.globalVariables[NUMBER_FORMAT].GetValue().value + "")),
                 CastFunction(Return.VECTOR, p => VectorToString(CastVector(p))),
                 CastFunction(Return.COLOR, p => ColorToString(CastColor(p))),
                 CastFunction(Return.LIST, p => CastList(p).Print()),

--- a/EasyCommands/Program.cs
+++ b/EasyCommands/Program.cs
@@ -33,6 +33,7 @@ namespace IngameScript {
         public int maxItemTransfers = 10;
         #endregion
 
+        public static string NUMBER_FORMAT = "NUMBER_FORMAT";
 
         public static Program PROGRAM;
         static void Print(String str) { PROGRAM?.Echo(str); }
@@ -71,12 +72,13 @@ namespace IngameScript {
                 KeyValuePair("pi", GetStaticVariable(Math.PI)),
                 KeyValuePair("e", GetStaticVariable(Math.E)),
                 KeyValuePair("empty", EmptyList()),
-                KeyValuePair("x", GetStaticVariable(Vector(1 ,0, 0))),
+                KeyValuePair("x", GetStaticVariable(Vector(1, 0, 0))),
                 KeyValuePair("y", GetStaticVariable(Vector(0, 1, 0))),
                 KeyValuePair("z", GetStaticVariable(Vector(0, 0, 1))),
-                KeyValuePair("r", GetStaticVariable(Vector(1 ,0, 0))),
+                KeyValuePair("r", GetStaticVariable(Vector(1, 0, 0))),
                 KeyValuePair("g", GetStaticVariable(Vector(0, 1, 0))),
-                KeyValuePair("b", GetStaticVariable(Vector(0, 0, 1)))
+                KeyValuePair("b", GetStaticVariable(Vector(0, 0, 1))),
+                KeyValuePair(NUMBER_FORMAT, GetStaticVariable("#0.########"))
             );
         }
 

--- a/docs/EasyCommands/primitives.md
+++ b/docs/EasyCommands/primitives.md
@@ -135,6 +135,36 @@ if the "Gatling Turret" range < 600
 
 Internally numbers are stored using floating point precision (as is most of EasyCommands) so keep this in mind when trying to set really precise values.
 
+### Formatting Numbers In Your Output
+By default, the number format used to display numbers is "#0.########".  This means that numbers are rounded to the nearest 8 decimal places, and any values < 1 always include a 0 in front of the decimal:
+
+```
+set myNumber to .1
+print myNumber
+#0.1
+```
+
+You can change the number format used when displaying numbers by setting the global NUMBER_FORMAT variable.  Note that this will affect the format of all numbers output afterwards.
+
+```
+set global NUMBER_FORMAT to "$#0.00"
+set myNumber to .1
+print myNumber
+#$0.10
+
+set myNumber to 0.006
+print myNumber
+#$0.01
+
+set myNumber to 0.004
+print myNumber
+#$0.00
+```
+
+See the C# docs on [Standard](https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings "Standard") and [Custom](https://docs.microsoft.com/en-us/dotnet/standard/base-types/custom-numeric-format-strings "Custom") Number Formats for more information on available number formats.
+
+Note that the NUMBER_FORMAT is reverted back to the default if the script is restarted or re-parsed.
+
 ## Vectors
 
 Vectors represent 3D coordinates and are used for a variety of purposes, such as for positions, directions, target locations, detected entity locations, and some other interesting properties.  They take the form ```x:y:z``` where x,y,z represent the x,y,z coordinates, respectively.

--- a/docs/EasyCommands/variables.md
+++ b/docs/EasyCommands/variables.md
@@ -63,6 +63,7 @@ Supported Variables:
 * ```pi``` - Pi
 * ```e``` - Euler's number, useful for e^(myValue)
 * ```empty``` - An empty list, useful for comparison (if myList is empty)
+* ```NUMBER_FORMAT``` - The number format used when outputting numerical values. See [Numbers](https://spaceengineers.merlinofmines.com/EasyCommands/primitives#numbers "Numbers") for more information.
 
 ```
 #x = 1:0:0


### PR DESCRIPTION
This commit adds a new global variable for "NUMBER_FORMAT" which the user can now set from their script to change the number format used when outputing numbers.

It also changes the default number format used to \#0.\#\#\#\#\#\#\#\#, which ensures that large numbers are not truncated using scientific notation.

This PR fixes #252 