### PR TITLE
Updated Aggregators to adhere to vacuous truth principles

### DIFF
--- a/EasyCommands.Tests/EasyCommands.Tests.csproj
+++ b/EasyCommands.Tests/EasyCommands.Tests.csproj
@@ -147,7 +147,9 @@
     <Compile Include="ScriptTests\FunctionalTests\Commands\MultiWordPropertyBlockCommandTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Commands\ComplexBlockCommandTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Selectors\SelectorWordTests.cs" />
+    <Compile Include="ScriptTests\FunctionalTests\Variables\SelectorAggregateConditionTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\Variables\MultiWordPropertyAggregationTests.cs" />
+    <Compile Include="ScriptTests\FunctionalTests\Variables\ListAggregateConditionTests.cs" />
     <Compile Include="ScriptTests\MockGridTerminalSystem.cs" />
     <Compile Include="ScriptTests\FunctionalTests\BlockHandlers\SearchlightBlockTests.cs" />
     <Compile Include="ScriptTests\FunctionalTests\BlockHandlers\HeatVentBlockTests.cs" />

--- a/EasyCommands.Tests/ParameterParsingTests/BooleanLogicParameterProcessorTests.cs
+++ b/EasyCommands.Tests/ParameterParsingTests/BooleanLogicParameterProcessorTests.cs
@@ -80,7 +80,6 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             AggregateConditionVariable condition = (AggregateConditionVariable)conditionalCommand.condition;
             Assert.IsTrue(condition.entityProvider is BlockTypeSelector);
             Assert.AreEqual(Block.BATTERY, condition.entityProvider.GetBlockType());
-            Assert.AreEqual(AggregationMode.ANY, condition.aggregationMode);
             PropertySupplier property = GetDelegateProperty<PropertySupplier>("property", condition.blockCondition);
             Assert.AreEqual(Property.RATIO + "", property.propertyValues[0].propertyType);
 
@@ -103,7 +102,7 @@ namespace EasyCommands.Tests.ParameterParsingTests {
             AggregateConditionVariable condition = (AggregateConditionVariable)variable.a;
             Assert.IsTrue(condition.entityProvider is BlockTypeSelector);
             Assert.AreEqual(Block.BATTERY, condition.entityProvider.GetBlockType());
-            Assert.AreEqual(AggregationMode.ALL, condition.aggregationMode);
+            Assert.AreEqual(program.AllCondition, condition.aggregateCondition);
             PropertySupplier property = GetDelegateProperty<PropertySupplier>("property", condition.blockCondition);
             Assert.AreEqual(Property.RATIO + "", property.propertyValues[0].propertyType);
 

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Variables/ListAggregateConditionTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Variables/ListAggregateConditionTests.cs
@@ -1,0 +1,160 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using IngameScript;
+using Moq;
+using Sandbox.ModAPI.Ingame;
+using VRageMath;
+using static EasyCommands.Tests.ScriptTests.MockEntityUtility;
+
+namespace EasyCommands.Tests.ScriptTests {
+    [TestClass]
+    public class ListAggregateConditionTests {
+
+        [TestMethod]
+        public void AllOfEmptyListReturnsTrue() {
+            using (var test = new ScriptTest(@"
+set myList to []
+print all of myList[] > 0
+")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("True", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AllMatchReturnsTrue() {
+            using (var test = new ScriptTest(@"
+set myList to [2]
+print all of myList[] > 0
+")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("True", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AllWithoutMatchReturnsFalse() {
+            using (var test = new ScriptTest(@"
+set myList to [2,-1]
+print all of myList[] > 0
+")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("False", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AnyOfEmptyListReturnsFalse() {
+            using (var test = new ScriptTest(@"
+set myList to []
+print any of myList[] > 0
+")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("False", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AnyMatchReturnsTrue() {
+            using (var test = new ScriptTest(@"
+set myList to [2, -1]
+print any of myList[] > 0
+")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("True", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AnyWithoutMatchReturnsFalse() {
+            using (var test = new ScriptTest(@"
+set myList to [-2,-1]
+print any of myList[] > 0
+")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("False", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void NoneOfEmptyListReturnsTrue() {
+            using (var test = new ScriptTest(@"
+set myList to []
+print none of myList[] > 0
+")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("True", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void NoneMatchReturnsTrue() {
+            using (var test = new ScriptTest(@"
+set myList to [-2, -1]
+print none of myList[] > 0
+")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("True", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void NoneWithMatchReturnsFalse() {
+            using (var test = new ScriptTest(@"
+set myList to [2,-1]
+print none of myList[] > 0
+")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("False", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void NotAnyIsTheSameAsNone() {
+            using (var test = new ScriptTest(@"
+set myList to [2,-1]
+print none of myList[] > 0
+print not any of myList[] > 0
+")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("False", test.Logger[0]);
+                Assert.AreEqual("False", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void NotAnyIsTheSameAsNoneForEmptyList() {
+            using (var test = new ScriptTest(@"
+set myList to []
+print none of myList[] > 0
+print not any of myList[] > 0
+")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("True", test.Logger[0]);
+                Assert.AreEqual("True", test.Logger[1]);
+            }
+        }
+    }
+}

--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Variables/SelectorAggregateConditionTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Variables/SelectorAggregateConditionTests.cs
@@ -1,0 +1,154 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using IngameScript;
+using Moq;
+using Sandbox.ModAPI.Ingame;
+using VRageMath;
+using static EasyCommands.Tests.ScriptTests.MockEntityUtility;
+
+namespace EasyCommands.Tests.ScriptTests {
+    [TestClass]
+    public class SelectorAggregateConditionTests {
+
+        [TestMethod]
+        public void AllOfEmptySelectorReturnsTrue() {
+            using (var test = new ScriptTest(@"
+print all of my pistons height > 5
+")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("True", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AllMatchReturnsTrue() {
+            using (var test = new ScriptTest(@"
+print all of my pistons height > 5
+")) {
+                var mockPiston = new Mock<IMyPistonBase>();
+                mockPiston.Setup(b => b.CurrentPosition).Returns(10);
+                test.MockBlocksOfType("My Piston", mockPiston);
+
+                test.RunOnce();
+
+                Assert.AreEqual("True", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AllWithoutMatchReturnsFalse() {
+            using (var test = new ScriptTest(@"
+print all of my pistons height > 5
+")) {
+                var mockPiston = new Mock<IMyPistonBase>();
+                var mockPiston2 = new Mock<IMyPistonBase>();
+                mockPiston.Setup(b => b.CurrentPosition).Returns(10);
+                mockPiston2.Setup(b => b.CurrentPosition).Returns(3);
+                test.MockBlocksOfType("My Piston", mockPiston);
+                test.MockBlocksOfType("My Piston 2", mockPiston2);
+
+                test.RunOnce();
+
+                Assert.AreEqual("False", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AnyOfEmptySelectorReturnsFalse() {
+            using (var test = new ScriptTest(@"
+print any of my pistons height > 5
+")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("False", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AnyMatchReturnsTrue() {
+            using (var test = new ScriptTest(@"
+print any of my pistons height > 5
+")) {
+                var mockPiston = new Mock<IMyPistonBase>();
+                var mockPiston2 = new Mock<IMyPistonBase>();
+                mockPiston.Setup(b => b.CurrentPosition).Returns(10);
+                mockPiston2.Setup(b => b.CurrentPosition).Returns(3);
+                test.MockBlocksOfType("My Piston", mockPiston);
+                test.MockBlocksOfType("My Piston 2", mockPiston2);
+
+                test.RunOnce();
+
+                Assert.AreEqual("True", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void AnyWithoutMatchReturnsFalse() {
+            using (var test = new ScriptTest(@"
+print all of my pistons height > 5
+")) {
+                var mockPiston = new Mock<IMyPistonBase>();
+                var mockPiston2 = new Mock<IMyPistonBase>();
+                mockPiston.Setup(b => b.CurrentPosition).Returns(4);
+                mockPiston2.Setup(b => b.CurrentPosition).Returns(3);
+                test.MockBlocksOfType("My Piston", mockPiston);
+                test.MockBlocksOfType("My Piston 2", mockPiston2);
+
+                test.RunOnce();
+
+                Assert.AreEqual("False", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void NoneOfEmptySelectorReturnsTrue() {
+            using (var test = new ScriptTest(@"
+print none of my pistons height > 5
+")) {
+
+                test.RunOnce();
+
+                Assert.AreEqual("True", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void NoneWithMatchReturnsFalse() {
+            using (var test = new ScriptTest(@"
+print none of my pistons height > 5
+")) {
+                var mockPiston = new Mock<IMyPistonBase>();
+                var mockPiston2 = new Mock<IMyPistonBase>();
+                mockPiston.Setup(b => b.CurrentPosition).Returns(10);
+                mockPiston2.Setup(b => b.CurrentPosition).Returns(3);
+                test.MockBlocksOfType("My Piston", mockPiston);
+                test.MockBlocksOfType("My Piston 2", mockPiston2);
+
+                test.RunOnce();
+
+                Assert.AreEqual("False", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void NoneWithoutMatchReturnsTrue() {
+            using (var test = new ScriptTest(@"
+print none of my pistons height > 5
+")) {
+                var mockPiston = new Mock<IMyPistonBase>();
+                var mockPiston2 = new Mock<IMyPistonBase>();
+                mockPiston.Setup(b => b.CurrentPosition).Returns(4);
+                mockPiston2.Setup(b => b.CurrentPosition).Returns(3);
+                test.MockBlocksOfType("My Piston", mockPiston);
+                test.MockBlocksOfType("My Piston 2", mockPiston2);
+
+                test.RunOnce();
+
+                Assert.AreEqual("True", test.Logger[0]);
+            }
+        }
+    }
+}

--- a/EasyCommands/CommandParsers/CommandParameters.cs
+++ b/EasyCommands/CommandParsers/CommandParameters.cs
@@ -240,8 +240,8 @@ namespace IngameScript {
             public RepetitionCommandParameter(IVariable value) : base(value) {}
         }
 
-        public class AggregationModeCommandParameter : ValueCommandParameter<AggregationMode> {
-            public AggregationModeCommandParameter(AggregationMode value) : base(value) {
+        public class AggregateConditionCommandParameter : ValueCommandParameter<AggregateCondition> {
+            public AggregateConditionCommandParameter(AggregateCondition value) : base(value) {
             }
         }
 

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -233,9 +233,9 @@ namespace IngameScript {
             AddWords(Words("contain", "contains"), new ComparisonCommandParameter((a, b) => CastBoolean(PerformOperation(BiOperand.CONTAINS, a, b))));
 
             //Aggregation Words
-            AddWords(Words("any"), new AggregationModeCommandParameter(AggregationMode.ANY));
-            AddWords(Words("all"), new AggregationModeCommandParameter(AggregationMode.ALL));
-            AddWords(Words("none"), new AggregationModeCommandParameter(AggregationMode.NONE));
+            AddWords(Words("any"), new AggregateConditionCommandParameter((count, matches) => matches > 0));
+            AddWords(Words("all"), new AggregateConditionCommandParameter(AllCondition));
+            AddWords(Words("none"), new AggregateConditionCommandParameter(NoneCondition));
             AddWords(Words("average", "avg"), new PropertyAggregationCommandParameter((blocks, primitiveSupplier) => SumAggregator(blocks, primitiveSupplier).Divide(ResolvePrimitive(Math.Max(1, blocks.Count())))));
             AddWords(Words("minimum", "min"), new PropertyAggregationCommandParameter((blocks, primitiveSupplier) => blocks.Select(primitiveSupplier).Min() ?? ResolvePrimitive(0)));
             AddWords(Words("maximum", "max"), new PropertyAggregationCommandParameter((blocks, primitiveSupplier) => blocks.Select(primitiveSupplier).Max() ?? ResolvePrimitive(0)));

--- a/EasyCommands/CommandParsers/ProcessingEngine.cs
+++ b/EasyCommands/CommandParsers/ProcessingEngine.cs
@@ -152,8 +152,8 @@ namespace IngameScript {
                 (list, aggregation) => new VariableCommandParameter(new ListAggregateVariable(list.value, aggregation.value))),
 
             //ListComparisonProcessor
-            ThreeValueRule(Type<ListIndexCommandParameter>, requiredRight<ComparisonCommandParameter>(), requiredRight<VariableCommandParameter>(), optionalLeft<AggregationModeCommandParameter>(),
-                (list, comparison, value, aggregation) => new VariableCommandParameter(new ListAggregateConditionVariable(aggregation?.value ?? AggregationMode.ALL, list.value, comparison.value, value.value))),
+            ThreeValueRule(Type<ListIndexCommandParameter>, requiredRight<ComparisonCommandParameter>(), requiredRight<VariableCommandParameter>(), optionalLeft<AggregateConditionCommandParameter>(),
+                (list, comparison, value, aggregation) => new VariableCommandParameter(new ListAggregateConditionVariable(aggregation?.value ?? PROGRAM.AllCondition, list.value, comparison.value, value.value))),
 
             //ListIndexAsVariableProcessor
             NoValueRule(Type<ListIndexCommandParameter>, list => new VariableCommandParameter(list.value)),
@@ -246,7 +246,7 @@ namespace IngameScript {
                 (p, selector, condition) => new SelectorCommandParameter(new ConditionalSelector(selector.value, condition.value))),
 
             //Re-arrange PropertyValueCommandParameters
-            TwoValueRule(Type<PropertyValueCommandParameter>, optionalRight<AggregationModeCommandParameter>(), optionalRight<SelectorCommandParameter>(),
+            TwoValueRule(Type<PropertyValueCommandParameter>, optionalRight<AggregateConditionCommandParameter>(), optionalRight<SelectorCommandParameter>(),
                 (p, a, s) => AnyNotNull(a.GetValue(), s.GetValue()),
                 (p, a, s) => NewList<ICommandParameter>(a, s, p).Where(c => c != null).ToList()),
 
@@ -260,12 +260,12 @@ namespace IngameScript {
                 (p, prop, dir, var) => new BlockConditionCommandParameter(BlockPropertyCondition(new PropertySupplier(prop.Select(v => v.value).ToList()).WithDirection(dir?.value), new PrimitiveComparator(p.value), var?.value ?? GetStaticVariable(true)))),
 
             //AggregateConditionProcessor
-            TwoValueRule(Type<BlockConditionCommandParameter>, optionalLeft<AggregationModeCommandParameter>(), requiredLeft<SelectorCommandParameter>(),
-                (p, aggregation, selector) => new VariableCommandParameter(new AggregateConditionVariable(aggregation?.value ?? AggregationMode.ALL, p.value, selector.value))),
+            TwoValueRule(Type<BlockConditionCommandParameter>, optionalLeft<AggregateConditionCommandParameter>(), requiredLeft<SelectorCommandParameter>(),
+                (p, aggregation, selector) => new VariableCommandParameter(new AggregateConditionVariable(aggregation?.value ?? PROGRAM.AllCondition, p.value, selector.value))),
 
             //AggregateSelectorProcessor
-            OneValueRule(Type<AggregationModeCommandParameter>, requiredRight<SelectorCommandParameter>(),
-                (aggregation, selector) => aggregation.value != AggregationMode.NONE && selector.Satisfied(),
+            OneValueRule(Type<AggregateConditionCommandParameter>, requiredRight<SelectorCommandParameter>(),
+                (aggregation, selector) => aggregation.value != PROGRAM.NoneCondition && selector.Satisfied(),
                 (aggregation, selector) => selector),
 
             //RepetitionProcessor

--- a/EasyCommands/Common/Aggregators.cs
+++ b/EasyCommands/Common/Aggregators.cs
@@ -30,5 +30,9 @@ namespace IngameScript {
                 blockValues.All(v => v.returnType == Return.NUMERIC) ? blockValues.Aggregate((a, b) => a.Plus(b)) :
                 ResolvePrimitive(NewKeyedList(blockValues.Select(v => new StaticVariable(v))));
         };
+
+        public delegate bool AggregateCondition(int count, int matches);
+        public AggregateCondition AllCondition = (count, matches) => count == matches;
+        public AggregateCondition NoneCondition = (count, matches) => matches == 0;
     }
 }

--- a/EasyCommands/Common/Types.cs
+++ b/EasyCommands/Common/Types.cs
@@ -149,6 +149,5 @@ namespace IngameScript {
         public enum Return { NUMERIC, BOOLEAN, STRING, VECTOR, COLOR, LIST, DEFAULT }
         public enum BiOperand { ADD, SUBTRACT, MULTIPLY, DIVIDE, MOD, AND, OR, COMPARE, DOT, EXPONENT, RANGE, CAST, CONTAINS, SPLIT, JOIN, ROUND };
         public enum UniOperand { REVERSE, ABS, SQRT, SIN, COS, TAN, ASIN, ACOS, ATAN, ROUND, KEYS, VALUES, TICKS, SORT, LN, RANDOM, SHUFFLE, SIGN, CAST, TYPE};
-        public enum AggregationMode {ANY, ALL, NONE }
     }
 }

--- a/EasyCommands/Common/Variables.cs
+++ b/EasyCommands/Common/Variables.cs
@@ -87,13 +87,13 @@ namespace IngameScript {
         }
 
         public class ListAggregateConditionVariable : IVariable {
-            public AggregationMode aggregationMode;
+            public AggregateCondition aggregateCondition;
             public IVariable expectedList;
             public PrimitiveComparator comparator;
             public IVariable comparisonValue;
 
-            public ListAggregateConditionVariable(AggregationMode aggregation, IVariable list, PrimitiveComparator comp, IVariable value) {
-                aggregationMode = aggregation;
+            public ListAggregateConditionVariable(AggregateCondition aggregation, IVariable list, PrimitiveComparator comp, IVariable value) {
+                aggregateCondition = aggregation;
                 expectedList = list;
                 comparator = comp;
                 comparisonValue = value;
@@ -101,33 +101,24 @@ namespace IngameScript {
 
             public Primitive GetValue() {
                 var list = CastList(expectedList.GetValue());
-                return ResolvePrimitive(Evaluate(list.keyedValues.Count, list.keyedValues.Count(v => comparator(v.GetValue(), comparisonValue.GetValue())), aggregationMode));
+                return ResolvePrimitive(aggregateCondition(list.keyedValues.Count, list.keyedValues.Count(v => comparator(v.GetValue(), comparisonValue.GetValue()))));
             }
         }
 
         public class AggregateConditionVariable : IVariable {
-            public AggregationMode aggregationMode;
+            public AggregateCondition aggregateCondition;
             public BlockCondition blockCondition;
             public ISelector entityProvider;
 
-            public AggregateConditionVariable(AggregationMode aggregation, BlockCondition condition, ISelector provider) {
-                aggregationMode = aggregation;
+            public AggregateConditionVariable(AggregateCondition aggregation, BlockCondition condition, ISelector provider) {
+                aggregateCondition = aggregation;
                 blockCondition = condition;
                 entityProvider = provider;
             }
 
             public Primitive GetValue() {
                 var blocks = entityProvider.GetEntities();
-                return ResolvePrimitive(Evaluate(blocks.Count, blocks.Count(block => blockCondition(block, entityProvider.GetBlockType())), aggregationMode));
-            }
-        }
-
-        public static bool Evaluate(int count, int matches, AggregationMode aggregation) {
-            switch (aggregation) {
-                case AggregationMode.ALL: return count > 0 && matches == count;
-                case AggregationMode.ANY: return matches > 0;
-                case AggregationMode.NONE: return matches == 0;
-                default: throw new RuntimeException("Unsupported Aggregation Mode");
+                return ResolvePrimitive(aggregateCondition(blocks.Count, blocks.Count(block => blockCondition(block, entityProvider.GetBlockType()))));
             }
         }
 


### PR DESCRIPTION
This commit changes aggregation logic so that all/none of an empty list or selector returns true (previously was false).

This commit also removes some characters by refactoring and removing AggregationMode