### PR TITLE
Added support for turning off rotor limits

### DIFF
--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/RotorBlockTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/BlockHandlers/RotorBlockTests.cs
@@ -119,6 +119,322 @@ set the ""rotor"" lower limit to 30
         }
 
         [TestMethod]
+        public void isUpperLimitEnabled() {
+            String script = @"
+Print ""Enabled: "" + ""rotor"" upper limit is enabled
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+                MockBlockDefinition(mockRotor, "LargeStator");
+
+                mockRotor.Setup(b => b.UpperLimitDeg).Returns(30);
+                test.RunUntilDone();
+                mockRotor.Verify(b => b.UpperLimitDeg);
+
+                mockRotor.Setup(b => b.UpperLimitDeg).Returns(3000);
+                test.RunUntilDone();
+                mockRotor.Verify(b => b.UpperLimitDeg);
+
+                Assert.AreEqual(2, test.Logger.Count);
+                Assert.AreEqual("Enabled: True", test.Logger[0]);
+                Assert.AreEqual("Enabled: False", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void isUpperLimitTurnedOn() {
+            String script = @"
+Print ""Enabled: "" + ""rotor"" upper limit is turned on
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+                MockBlockDefinition(mockRotor, "LargeStator");
+
+                mockRotor.Setup(b => b.UpperLimitDeg).Returns(30);
+                test.RunUntilDone();
+                mockRotor.Verify(b => b.UpperLimitDeg);
+
+                mockRotor.Setup(b => b.UpperLimitDeg).Returns(3000);
+                test.RunUntilDone();
+                mockRotor.Verify(b => b.UpperLimitDeg);
+
+                Assert.AreEqual(2, test.Logger.Count);
+                Assert.AreEqual("Enabled: True", test.Logger[0]);
+                Assert.AreEqual("Enabled: False", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void turnOffUpperLimit() {
+            String script = @"
+turn off the ""rotor"" upper limit
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+                MockBlockDefinition(mockRotor, "LargeStator");
+
+                test.RunUntilDone();
+
+                mockRotor.VerifySet(b => b.UpperLimitDeg = 361);
+            }
+        }
+
+        [TestMethod]
+        public void disableUpperLimit() {
+            String script = @"
+disable the ""rotor"" upper limit
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+                MockBlockDefinition(mockRotor, "LargeStator");
+
+                test.RunUntilDone();
+
+                mockRotor.VerifySet(b => b.UpperLimitDeg = 361);
+            }
+        }
+
+        [TestMethod]
+        public void enableUpperLimit() {
+            String script = @"
+enable the ""rotor"" upper limit
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+                MockBlockDefinition(mockRotor, "LargeStator");
+                mockRotor.Setup(b => b.UpperLimitDeg).Returns(60);
+
+                test.RunUntilDone();
+
+                mockRotor.Verify(b => b.UpperLimitDeg);
+                mockRotor.Verify(b => b.CustomName);
+                mockRotor.Verify(b => b.BlockDefinition);
+                mockRotor.VerifyNoOtherCalls();
+            }
+        }
+
+        [TestMethod]
+        public void isLowerLimitEnabled() {
+            String script = @"
+Print ""Enabled: "" + ""rotor"" lower limit is enabled
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+                MockBlockDefinition(mockRotor, "LargeStator");
+
+                mockRotor.Setup(b => b.LowerLimitDeg).Returns(-30);
+                test.RunUntilDone();
+                mockRotor.Verify(b => b.LowerLimitDeg);
+
+                mockRotor.Setup(b => b.LowerLimitDeg).Returns(-3000);
+                test.RunUntilDone();
+                mockRotor.Verify(b => b.LowerLimitDeg);
+
+                Assert.AreEqual(2, test.Logger.Count);
+                Assert.AreEqual("Enabled: True", test.Logger[0]);
+                Assert.AreEqual("Enabled: False", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void isLowerLimitTurnedOn() {
+            String script = @"
+Print ""Enabled: "" + ""rotor"" lower limit is turned on
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+                MockBlockDefinition(mockRotor, "LargeStator");
+
+                mockRotor.Setup(b => b.LowerLimitDeg).Returns(-30);
+                test.RunUntilDone();
+                mockRotor.Verify(b => b.LowerLimitDeg);
+
+                mockRotor.Setup(b => b.LowerLimitDeg).Returns(-3000);
+                test.RunUntilDone();
+                mockRotor.Verify(b => b.LowerLimitDeg);
+
+                Assert.AreEqual(2, test.Logger.Count);
+                Assert.AreEqual("Enabled: True", test.Logger[0]);
+                Assert.AreEqual("Enabled: False", test.Logger[1]);
+            }
+        }
+
+        [TestMethod]
+        public void turnOffLowerLimit() {
+            String script = @"
+turn off the ""rotor"" lower limit
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+                MockBlockDefinition(mockRotor, "LargeStator");
+
+                test.RunUntilDone();
+
+                mockRotor.VerifySet(b => b.LowerLimitDeg = -361);
+            }
+        }
+
+        [TestMethod]
+        public void disableLowerLimit() {
+            String script = @"
+disable the ""rotor"" lower limit
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+                MockBlockDefinition(mockRotor, "LargeStator");
+
+                test.RunUntilDone();
+
+                mockRotor.VerifySet(b => b.LowerLimitDeg = -361);
+            }
+        }
+
+        [TestMethod]
+        public void enableLowerLimit() {
+            String script = @"
+enable the ""rotor"" lower limit
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+                MockBlockDefinition(mockRotor, "LargeStator");
+                mockRotor.Setup(b => b.LowerLimitDeg).Returns(60);
+
+                test.RunUntilDone();
+
+                mockRotor.Verify(b => b.LowerLimitDeg);
+                mockRotor.Verify(b => b.CustomName);
+                mockRotor.Verify(b => b.BlockDefinition);
+                mockRotor.VerifyNoOtherCalls();
+            }
+        }
+
+        [TestMethod]
+        public void areLimitsEnabled() {
+            String script = @"
+Print ""Enabled: "" + ""rotor"" limits are enabled
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+                MockBlockDefinition(mockRotor, "LargeStator");
+
+                mockRotor.Setup(b => b.LowerLimitDeg).Returns(-30);
+                mockRotor.Setup(b => b.UpperLimitDeg).Returns(30);
+                test.RunUntilDone();
+
+                mockRotor.Setup(b => b.LowerLimitDeg).Returns(-30);
+                mockRotor.Setup(b => b.UpperLimitDeg).Returns(3000);
+                test.RunUntilDone();
+
+                mockRotor.Setup(b => b.LowerLimitDeg).Returns(-3000);
+                mockRotor.Setup(b => b.UpperLimitDeg).Returns(30);
+                test.RunUntilDone();
+
+                mockRotor.Setup(b => b.LowerLimitDeg).Returns(-3000);
+                mockRotor.Setup(b => b.UpperLimitDeg).Returns(3000);
+                test.RunUntilDone();
+
+                Assert.AreEqual(4, test.Logger.Count);
+                Assert.AreEqual("Enabled: True", test.Logger[0]);
+                Assert.AreEqual("Enabled: True", test.Logger[1]);
+                Assert.AreEqual("Enabled: True", test.Logger[2]);
+                Assert.AreEqual("Enabled: False", test.Logger[3]);
+            }
+        }
+
+        [TestMethod]
+        public void areLimitsTurnedOn() {
+            String script = @"
+Print ""Enabled: "" + ""rotor"" limits are turned on
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+                MockBlockDefinition(mockRotor, "LargeStator");
+
+                mockRotor.Setup(b => b.LowerLimitDeg).Returns(-30);
+                mockRotor.Setup(b => b.UpperLimitDeg).Returns(30);
+                test.RunUntilDone();
+
+                mockRotor.Setup(b => b.LowerLimitDeg).Returns(-30);
+                mockRotor.Setup(b => b.UpperLimitDeg).Returns(3000);
+                test.RunUntilDone();
+
+                mockRotor.Setup(b => b.LowerLimitDeg).Returns(-3000);
+                mockRotor.Setup(b => b.UpperLimitDeg).Returns(30);
+                test.RunUntilDone();
+
+                mockRotor.Setup(b => b.LowerLimitDeg).Returns(-3000);
+                mockRotor.Setup(b => b.UpperLimitDeg).Returns(3000);
+                test.RunUntilDone();
+
+                Assert.AreEqual(4, test.Logger.Count);
+                Assert.AreEqual("Enabled: True", test.Logger[0]);
+                Assert.AreEqual("Enabled: True", test.Logger[1]);
+                Assert.AreEqual("Enabled: True", test.Logger[2]);
+                Assert.AreEqual("Enabled: False", test.Logger[3]);
+            }
+        }
+
+        [TestMethod]
+        public void turnOffLimits() {
+            String script = @"
+turn off the ""rotor"" limits
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+                MockBlockDefinition(mockRotor, "LargeStator");
+
+                test.RunUntilDone();
+
+                mockRotor.VerifySet(b => b.LowerLimitDeg = -361);
+                mockRotor.VerifySet(b => b.UpperLimitDeg = 361);
+            }
+        }
+
+        [TestMethod]
+        public void disableLimits() {
+            String script = @"
+disable the ""rotor"" limits
+";
+
+            using (ScriptTest test = new ScriptTest(script)) {
+                var mockRotor = new Mock<IMyMotorStator>();
+                test.MockBlocksOfType("rotor", mockRotor);
+                MockBlockDefinition(mockRotor, "LargeStator");
+
+                test.RunUntilDone();
+
+                mockRotor.VerifySet(b => b.LowerLimitDeg = -361);
+                mockRotor.VerifySet(b => b.UpperLimitDeg = 361);
+            }
+        }
+
+        [TestMethod]
         public void rotateTheRotorClockwise() {
             String script = @"
 rotate the ""rotor"" clockwise

--- a/EasyCommands/Common/Operations.cs
+++ b/EasyCommands/Common/Operations.cs
@@ -76,6 +76,7 @@ namespace IngameScript {
             AddBiOperation<bool, bool>(BiOperand.AND, (a, b) => a && b);
             AddBiOperation<bool, bool>(BiOperand.OR, (a, b) => a || b);
             AddBiOperation<bool, bool>(BiOperand.EXPONENT, (a, b) => a ^ b);
+            AddBiOperation<bool, bool>(BiOperand.ADD, (a, b) => a || b);
             AddBiOperation<String, object>(BiOperand.CONTAINS, (a, b) => a.Contains(CastString(ResolvePrimitive(b))));
             AddBiOperation<KeyedList, object>(BiOperand.CONTAINS, (a, b) => CastList(ResolvePrimitive(b)).keyedValues.Select(v => v.GetValue().value).Except(a.keyedValues.Select(v => v.GetValue().value)).Count() == 0);
 

--- a/docs/EasyCommands/blockHandlers/rotor.md
+++ b/docs/EasyCommands/blockHandlers/rotor.md
@@ -97,11 +97,13 @@ set "My Rotor" velocity to 5
 ```
 
 ## "Limit" Property
-* Primitive Type: Numeric
+* Primitive Type: Numeric/Boolean
 * Takes an optional direction
 * Keywords: ```limit, limits, range, ranges, distance, distances```
 
 Get/Sets the Piston's upper/lower limits, in degrees.  Takes in an optional direction to indicate whether you are getting or setting the upper or lower limit.  If no direction is specified, the upper limit is used.
+
+You can also use this property to disable the upper/lower or both limits for the rotor.
 
 ### Supported Directions
 * Up - Upper Limit
@@ -123,6 +125,25 @@ set "My Rotor" upper limit to 6
 
 #Set the lower limit
 set "My Rotor" lower limit to 4
+
+#Get whether the rotor has a lower limit
+Print "Has Lower Limit: " + "My Rotor" lower limit is enabled
+
+#Get whether the rotor has an upper limit
+Print "Has Upper Limit: " + "My Rotor" upper limit is enabled
+
+#Get whether the rotor has either an upper or lower limit enabled
+#Note this will return true if either an upper or lower limit is set.
+Print "Has Limit: " + "My Rotor" limits are enabled
+
+#Disable the upper limit
+turn off "My Rotor" upper limit
+
+#Disable the lower limit
+turn off "My Rotor lower limit
+
+#Disable both limits
+turn off "My Rotor" limits
 ```
 
 ## "Height" Property

--- a/docs/EasyCommands/operations.md
+++ b/docs/EasyCommands/operations.md
@@ -422,6 +422,7 @@ Keywords: ```plus, +```
 * **(Color, Color)**: Adds two colors together by adding together RGB values (capped at 255, of course)
 * **(List, Any)**: Adds the second item(s) to the first list, at the end
 * **(Any, List)**: Adds the first item(s) to the second list, inserted at the beginning
+* **(Boolean, Boolean)**: Same as Logical Or. Checks whether either boolean operand is true (a || b).
 
 ### And
 Checks whether both boolean operands are true (a && b)


### PR DESCRIPTION
This commit implements the ability to reset the rotor limits using a boolean handler.

This commit implements #260.

Pistons have not been implemented but this support doesn't appear to be needed.