### PR TITLE
Fix Simple Aggregate Property To Use Name if no property is set

### DIFF
--- a/EasyCommands.Tests/ScriptTests/FunctionalTests/Variables/SimpleAggregationTests.cs
+++ b/EasyCommands.Tests/ScriptTests/FunctionalTests/Variables/SimpleAggregationTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using Sandbox.ModAPI.Ingame;
 using VRageMath;
 using static EasyCommands.Tests.ScriptTests.MockEntityUtility;
+using SpaceEngineers.Game.ModAPI.Ingame;
 
 namespace EasyCommands.Tests.ScriptTests {
     [TestClass]
@@ -436,6 +437,39 @@ if the ""test thrusters"" are on
                 test.RunUntilDone();
 
                 Assert.AreEqual("Thrusters On!", test.Logger[0]);
+            }
+        }
+
+        [TestMethod]
+        public void BasicBlockAggregationWithNoDirectionOrProperty() {
+            using (var test = new ScriptTest(@"
+set myBatteries to ""My Batteries"" batteries
+turn off myBatteries[1] battery
+")) {
+                var mockBattery1 = new Mock<IMyBatteryBlock>();
+                var mockBattery2 = new Mock<IMyBatteryBlock>();
+                test.MockBlocksInGroup("My Batteries", mockBattery1, mockBattery2);
+
+                test.RunOnce();
+
+                mockBattery2.VerifySet(p => p.Enabled = false);
+            }
+        }
+
+        [TestMethod]
+        public void BlockAggregationWithNoDirectionOrPropertyWithNonNameStringDefault() {
+            using (var test = new ScriptTest(@"
+set mySpeakers to ""My Speakers"" speakers
+print mySpeakers
+turn off mySpeakers[1] speaker
+")) {
+                var mockSpeaker1 = new Mock<IMySoundBlock>();
+                var mockSpeaker2 = new Mock<IMySoundBlock>();
+                test.MockBlocksInGroup("My Speakers", mockSpeaker1, mockSpeaker2);
+
+                test.RunOnce();
+
+                mockSpeaker2.VerifySet(p => p.Enabled = false);
             }
         }
     }

--- a/EasyCommands/Common/Variables.cs
+++ b/EasyCommands/Common/Variables.cs
@@ -135,7 +135,8 @@ namespace IngameScript {
 
             public Primitive GetValue() {
                 IBlockHandler handler = BlockHandlerRegistry.GetBlockHandler(entityProvider.GetBlockType());
-                PropertySupplier p = property.Resolve(handler, Return.NUMERIC);
+                if (property.propertyValues.Count == 0) property = property.WithProperties(NewList(new PropertyValue(Property.NAME + "")));
+                PropertySupplier p = property.Resolve(handler, Return.STRING);
                 return aggregator(entityProvider.GetEntities(), b => handler.GetPropertyValue(b, p));
             }
         }


### PR DESCRIPTION
This small MR changes the default behavior of aggregate block properties so that the default values used when no property is specified, "names" is used.  This enables

```set myBatteries to "My Batteries" batteries"```

 to provide you the list of battery names, vs the unhelpful sum of battery ratios. 