### PR TITLE
Connector counterpart access

### DIFF
--- a/EasyCommands/BlockHandlers/ConnectorBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/ConnectorBlockHandlers.cs
@@ -31,6 +31,7 @@ namespace IngameScript {
                 AddPropertyHandler(Property.ABLE, readyHandler);
                 AddPropertyHandler(NewList(Property.ABLE, Property.LOCKED), readyHandler);
                 AddPropertyHandler(NewList(Property.ABLE, Property.CONNECTED), readyHandler);
+                AddStringHandler(Property.COUNTERPART, b => b.OtherConnector?.CustomName ?? "");
 
                 defaultPropertiesByPrimitive[Return.NUMERIC] = Property.STRENGTH;
             }

--- a/EasyCommands/CommandParsers/ParameterParsers.cs
+++ b/EasyCommands/CommandParsers/ParameterParsers.cs
@@ -188,6 +188,7 @@ namespace IngameScript {
             AddPropertyWords(Words("unable"), Property.ABLE, false);
             AddPropertyWords(Words("build", "building", "built"), Property.BUILD);
             AddPropertyWords(Words("damage", "damaged"), Property.DAMAGE);
+            AddPropertyWords(Words("counterpart", "other", "complement", "connection"), Property.COUNTERPART);
 
             //ValueProperty Words
             AddWords(PluralWords("amount"), new ValuePropertyCommandParameter(Property.AMOUNT));

--- a/EasyCommands/Common/Types.cs
+++ b/EasyCommands/Common/Types.cs
@@ -96,6 +96,7 @@ namespace IngameScript {
             COMPLETE,
             CONNECTED,
             COUNTDOWN,
+            COUNTERPART,
             DAMAGE,
             DATA,
             DIRECTION,


### PR DESCRIPTION
These changes provide access to IMyShipConnector's OtherConnector value, which is blockref for the connector on the other side of a docked connector's docking interface

Have minified these changes in-place in an in-game copy of this script;  changes are functional, do not appear to produce any bugs or glitches, and throw no errors