### PR TITLE
Update SorterBlockHandlers.cs

### DIFF
--- a/EasyCommands/BlockHandlers/SorterBlockHandlers.cs
+++ b/EasyCommands/BlockHandlers/SorterBlockHandlers.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using static IngameScript.Program;
 
 namespace IngameScript
 {


### PR DESCRIPTION
removal of `using IngameScript.Program`
Whilst ignored by MDK1, it breaks compilation under MDK2 and Malware said to remove it